### PR TITLE
Map internal dependencies for Chapter1 opening blob batch

### DIFF
--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -1,0 +1,54 @@
+{
+  "Chapter1/01_00_Introduction": [],
+  "Chapter1/01_01_Remark": [
+    "Chapter1/01_00_Introduction"
+  ],
+  "Chapter1/01_01a_Discussion": [
+    "Chapter1/01_01_Remark"
+  ],
+  "Chapter1/01_02_Definition": [
+    "Chapter1/01_01a_Discussion"
+  ],
+  "Chapter1/01_03_Example": [
+    "Chapter1/01_02_Definition"
+  ],
+  "Chapter1/01_04_Lemma": [
+    "Chapter1/01_02_Definition"
+  ],
+  "Chapter1/01_04_Proof": [
+    "Chapter1/01_04_Lemma"
+  ],
+  "Chapter1/01_05_Corollary": [
+    "Chapter1/01_04_Lemma"
+  ],
+  "Chapter1/01_05_Proof": [
+    "Chapter1/01_05_Corollary",
+    "Chapter1/01_04_Lemma"
+  ],
+  "Chapter1/01_06_Definition": [
+    "Chapter1/01_02_Definition"
+  ],
+  "Chapter1/01_06a_Discussion": [
+    "Chapter1/01_06_Definition"
+  ],
+  "Chapter1/01_07_Definition": [
+    "Chapter1/01_06a_Discussion"
+  ],
+  "Chapter1/01_08_Theorem": [
+    "Chapter1/01_06_Definition",
+    "Chapter1/01_07_Definition"
+  ],
+  "Chapter1/01_08_Proof": [
+    "Chapter1/01_08_Theorem"
+  ],
+  "Chapter1/01_09_Theorem": [
+    "Chapter1/01_07_Definition"
+  ],
+  "Chapter1/01_09_Proof": [
+    "Chapter1/01_09_Theorem",
+    "Chapter1/01_07_Definition"
+  ],
+  "Chapter1/01_09a_Discussion": [
+    "Chapter1/01_09_Proof"
+  ]
+}

--- a/progress/2026-04-20T09-11-04Z.md
+++ b/progress/2026-04-20T09-11-04Z.md
@@ -1,0 +1,18 @@
+## Accomplished
+Created `dependencies/internal.json` for the opening Chapter 1 batch `01_00` through `01_09a` with exactly one entry per assigned blob and direct dependencies only.
+Replaced blind predecessor links with explicit direct references where the text warranted it, including `01_04_Lemma -> 01_02_Definition`, `01_05_Corollary -> 01_04_Lemma`, `01_08_Theorem -> {01_06_Definition, 01_07_Definition}`, and `01_09_Theorem -> 01_07_Definition`.
+Updated `progress/status.json` so the assigned opening blobs are marked `internal_dependencies_mapped`.
+
+## Current frontier
+Stage 2.1 has now started on Chapter 1 and the opening batch is mapped. The parallel opening-batch Stage 2.2 issue `#50` remains unclaimed, and PR `#49` for the tail extraction batch is still conflict-marked.
+
+## Overall project progress
+Stage 1.6 structure analysis is complete for logical pages `1` through `7`.
+Stage 1.7 blob extraction is complete for Chapter 1 items `01_00` through `01_19`, with `01_20` through `01_29a` still waiting on the conflicted PR `#49`.
+Stage 2.1 is complete for the opening Chapter 1 batch `01_00` through `01_09a`; later Chapter 1 blobs still need internal dependency mapping, and no Stage 2.2 output is merged yet.
+
+## Next step
+Claim issue `#50` to map external prerequisites for the same opening batch while the blob contents are still fresh, unless a new fix issue is created first for PR `#49`.
+
+## Blockers
+None for issue `#51`; the only nearby project blocker is the unresolved merge conflict on PR `#49`, which is outside this issue's scope.

--- a/progress/status.json
+++ b/progress/status.json
@@ -42,106 +42,106 @@
     "notes": "Stage 1.6 structure analysis assigned every line on logical pages 1 through 7 to ordered items in items.json; page 7 covers Definition 1.26, Remark 1.27, Proposition 1.28 with proof, Example 1.29, and the references bibliography."
   },
   "Chapter1/01_00_Introduction": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/1.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this introduction now has an explicit empty direct-dependency list in dependencies/internal.json."
   },
   "Chapter1/01_01_Remark": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/1.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this remark conservatively depends on the chapter introduction."
   },
   "Chapter1/01_01a_Discussion": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/1.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this discussion note keeps the local predecessor dependency chain."
   },
   "Chapter1/01_02_Definition": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/1.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this definition currently depends only on the immediately preceding discussion blob."
   },
   "Chapter1/01_03_Example": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this example depends directly on Definition 1.2."
   },
   "Chapter1/01_04_Lemma": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this lemma depends directly on the absolute-value definition rather than the preceding example."
   },
   "Chapter1/01_04_Proof": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this proof blob depends on its lemma statement."
   },
   "Chapter1/01_05_Corollary": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this corollary explicitly depends on Lemma 1.4."
   },
   "Chapter1/01_05_Proof": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this proof depends on the corollary statement and the cited lemma."
   },
   "Chapter1/01_06_Definition": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; equivalence of absolute values depends directly on Definition 1.2."
   },
   "Chapter1/01_06a_Discussion": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this section-transition discussion depends on the preceding equivalence definition."
   },
   "Chapter1/01_07_Definition": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; the p-adic setup depends on the preceding discussion of factorizations on Q."
   },
   "Chapter1/01_08_Theorem": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; Ostrowski's theorem depends directly on equivalence of absolute values and the p-adic absolute value."
   },
   "Chapter1/01_08_Proof": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this proof placeholder depends on the theorem statement."
   },
   "Chapter1/01_09_Theorem": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; the product formula depends directly on the p-adic absolute-value definition."
   },
   "Chapter1/01_09_Proof": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/2.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this proof placeholder depends on the theorem statement and the p-adic absolute-value definition."
   },
   "Chapter1/01_09a_Discussion": {
-    "status": "extracted",
+    "status": "internal_dependencies_mapped",
     "last_updated": "2026-04-20",
-    "issue": "#45",
-    "notes": "Stage 1.7 blob extraction created this blob from items.json and pages/3.md."
+    "issue": "#51",
+    "notes": "Stages 1.7 and 2.1 complete for the opening batch; this section heading keeps the immediate-predecessor dependency."
   },
   "Chapter1/01_10_Definition": {
     "status": "extracted",


### PR DESCRIPTION
Closes #51

## Summary
- create `dependencies/internal.json` for Chapter1 blobs `01_00` through `01_09a`
- capture direct internal references instead of storing transitive closure
- update `progress/status.json` and add the required progress handoff file