### PR TITLE
Review scaffolding for Chapter1/01_03_Example

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_03_Example.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_03_Example.lean
@@ -17,30 +17,44 @@ section Example_01_03
 
 variable {k : Type*} [Field k]
 
-/-- The lecture's piecewise formula is Mathlib's packaged trivial absolute value. -/
-noncomputable example : AbsoluteValue k ℝ := by
+/-- The lecture's trivial absolute value is Mathlib's packaged `AbsoluteValue.trivial`. -/
+noncomputable def trivialAbsoluteValue : AbsoluteValue k ℝ := by
   classical
-  exact AbsoluteValue.trivial
+  exact AbsoluteValue.trivial (R := k) (S := ℝ)
+
+/-- The zero branch of the lecture's piecewise formula. -/
+@[simp] theorem trivialAbsoluteValue_apply_zero :
+    trivialAbsoluteValue (k := k) 0 = 0 := by
+  simp [trivialAbsoluteValue]
 
 /-- Away from zero, the trivial absolute value takes the constant value `1`. -/
-example {x : k} (hx : x ≠ 0) : (show AbsoluteValue k ℝ from by
-    classical
-    exact AbsoluteValue.trivial (R := k) (S := ℝ)) x = 1 := by
+theorem trivialAbsoluteValue_apply_of_ne_zero {x : k} (hx : x ≠ 0) :
+    trivialAbsoluteValue (k := k) x = 1 := by
   classical
-  simpa using AbsoluteValue.trivial_apply (S := ℝ) hx
+  simpa [trivialAbsoluteValue] using AbsoluteValue.trivial_apply (S := ℝ) hx
 
 /-- Example 1.3 explicitly records that the trivial absolute value is nonarchimedean. -/
-theorem trivial_isNonarchimedean : IsNonarchimedean (show AbsoluteValue k ℝ from by
-    classical
-    exact AbsoluteValue.trivial (R := k) (S := ℝ)) := by
+theorem trivialAbsoluteValue_isNonarchimedean :
+    IsNonarchimedean (trivialAbsoluteValue (k := k)) := by
   classical
   intro x y
   by_cases hx : x = 0
-  · simp [AbsoluteValue.trivial, hx]
+  · simp [trivialAbsoluteValue, hx]
   by_cases hy : y = 0
-  · simp [AbsoluteValue.trivial, hy]
-  simp [AbsoluteValue.trivial, hx, hy]
-  split_ifs <;> norm_num
+  · simp [trivialAbsoluteValue, hy]
+  by_cases hxy : x + y = 0
+  · have hx1 : trivialAbsoluteValue (k := k) x = 1 :=
+      trivialAbsoluteValue_apply_of_ne_zero (k := k) hx
+    have hy1 : trivialAbsoluteValue (k := k) y = 1 :=
+      trivialAbsoluteValue_apply_of_ne_zero (k := k) hy
+    simp [hxy, hx1, hy1]
+  · have hx1 : trivialAbsoluteValue (k := k) x = 1 :=
+      trivialAbsoluteValue_apply_of_ne_zero (k := k) hx
+    have hy1 : trivialAbsoluteValue (k := k) y = 1 :=
+      trivialAbsoluteValue_apply_of_ne_zero (k := k) hy
+    have hxy1 : trivialAbsoluteValue (k := k) (x + y) = 1 :=
+      trivialAbsoluteValue_apply_of_ne_zero (k := k) hxy
+    simp [hx1, hy1, hxy1]
 
 end Example_01_03
 

--- a/progress/2026-04-20T19-11-47Z.md
+++ b/progress/2026-04-20T19-11-47Z.md
@@ -1,0 +1,22 @@
+## Accomplished
+- Claimed review issue `#119` for `Chapter1/01_03_Example`.
+- Performed the Stage `3.2` coverage audit against `blobs/Chapter1/01_03_Example.md` and `SutherlandNumberTheoryLecture1/Chapter1/01_03_Example.lean`.
+- Replaced anonymous declarations in the Lean file with named review-quality declarations: `trivialAbsoluteValue`, `trivialAbsoluteValue_apply_zero`, `trivialAbsoluteValue_apply_of_ne_zero`, and `trivialAbsoluteValue_isNonarchimedean`.
+- Ran `lake exe cache get` for the session and verified the repository builds with `lake build`.
+- Updated `progress/status.json` so `Chapter1/01_03_Example` is now `definition_verified`.
+
+## Current frontier
+- `Chapter1/01_03_Example` passed Stage `3.2`: the blob's claims are now explicitly covered by named Lean declarations, with no definition-level `sorry`.
+- The remaining early opening-batch frontier is still gated by the unresolved PR conflicts on `#94`, `#97`, and `#103`, so the next reviewable opening-batch item is not yet on `master`.
+
+## Overall project progress
+- Logical pages `1` through `7` remain fully transcribed, validated, structured, and blobbed.
+- The current extracted Chapter 1 slice remains fully through Stage `2.6`.
+- Stage `3.2` has now started successfully on merged Stage `3.1` items: `Chapter1/01_03_Example` is the first item in the current worktree advanced to `definition_verified`.
+
+## Next step
+- Push and open the review PR for `#119` with the Stage `3.2` coverage-audit checklist in the PR body.
+- After this merges, queue Stage `3.3` missing-claims audit work for `Chapter1/01_03_Example` when the chapter has enough `definition_verified` neighbors; on the opening batch itself, the next immediate review frontier is `Chapter1/01_06_Definition` once PR `#103` is conflict-free and merged.
+
+## Blockers
+- PRs `#94`, `#97`, and `#103` are still merge-conflicted, so the broader opening-batch Stage `3.1`/`3.2` pipeline remains partially blocked on `master`.

--- a/progress/status.json
+++ b/progress/status.json
@@ -143,10 +143,10 @@
     "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_02_Definition.lean by recalling Mathlib's `AbsoluteValue` for axioms (1)-(3) and isolating the nonarchimedean strengthening as `isNonarchimedean_iff`."
   },
   "Chapter1/01_03_Example": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-20",
-    "issue": "#98",
-    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_03_Example.lean by recording the lecture's piecewise formula as Mathlib's `AbsoluteValue.trivial` and stating explicitly that this absolute value is nonarchimedean."
+    "issue": "#119",
+    "notes": "Stage 3.2 review for SutherlandNumberTheoryLecture1/Chapter1/01_03_Example.lean passed after replacing anonymous declarations with named bridges: `trivialAbsoluteValue`, its zero/nonzero branch lemmas matching the textbook's piecewise formula, and `trivialAbsoluteValue_isNonarchimedean`."
   },
   "Chapter1/01_04_Lemma": {
     "status": "references_attached",


### PR DESCRIPTION
## Summary
- replace anonymous Example 1.3 declarations with named review-quality declarations
- add explicit zero and nonzero bridges for the textbook's piecewise trivial absolute value formula
- mark `Chapter1/01_03_Example` as `definition_verified` and record the handoff in `progress/2026-04-20T19-11-47Z.md`

## Verification
- `lake build`

## Stage 3.2 Coverage Audit
- [x] Enumerate claims
  Claim 1: the piecewise map sending `0` to `0` and every nonzero element to `1` is the trivial absolute value on `k`.
  Claim 2: this trivial absolute value is nonarchimedean.
- [x] Map to Lean
  Claim 1 is covered by `trivialAbsoluteValue`, together with `trivialAbsoluteValue_apply_zero` and `trivialAbsoluteValue_apply_of_ne_zero` in [SutherlandNumberTheoryLecture1/Chapter1/01_03_Example.lean](/home/kim/Sutherland-NumberTheory-Lecture1-draft3/worktrees/cf1ca0ca/SutherlandNumberTheoryLecture1/Chapter1/01_03_Example.lean).
  Claim 2 is covered by `trivialAbsoluteValue_isNonarchimedean` in the same file.
- [x] Flag gaps
  No coverage gaps remain for the blob.
- [x] Check non-trivial equivalences
  The bridge from the lecture's piecewise formula to Mathlib's packaged object is now explicit through the named `trivialAbsoluteValue` declaration plus the zero/nonzero branch lemmas; no extra equivalence theorem is needed beyond those branches.
- [x] Check definition integrity
  No data declarations use `sorry`; `lake build` succeeds after the review patch.

Closes #119
