### PR TITLE
Repair PR #103 Chapter1/01_06_Definition conflicts

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1.lean
@@ -6,6 +6,7 @@ Authors: FormalFrontier contributors
 import Mathlib
 import SutherlandNumberTheoryLecture1.Chapter1.«01_02_Definition»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_03_Example»
+import SutherlandNumberTheoryLecture1.Chapter1.«01_06_Definition»
 
 /-!
 # Chapter 1 import spine

--- a/SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean
@@ -1,0 +1,41 @@
+import Mathlib
+
+/-!
+# Definition 1.6: Equivalent absolute values
+
+The lecture defines two absolute values `|.|` and `|.|'` on the same field to be
+equivalent when there is a positive real exponent `α` such that `|x|' = |x|^α`
+for every `x`. Mathlib's core notion is `AbsoluteValue.IsEquiv`, and
+`AbsoluteValue.isEquiv_iff_exists_rpow_eq` gives exactly the bridge to the
+lecture's exponentiation phrasing.
+-/
+
+recall AbsoluteValue.IsEquiv {R : Type u_1} [Semiring R] {S : Type u_2} [Semiring S]
+  [PartialOrder S] (v w : AbsoluteValue R S) : Prop
+
+namespace SutherlandNumberTheoryLecture1
+namespace Chapter1
+
+section Definition_01_06
+
+variable {k : Type*} [Field k]
+
+/-- Definition 1.6 written in the lecture's `|x|' = |x|^α` form. -/
+theorem isEquiv_iff_exists_forall_rpow_eq (v w : AbsoluteValue k ℝ) :
+    v.IsEquiv w ↔ ∃ α : ℝ, 0 < α ∧ ∀ x : k, w x = v x ^ α := by
+  constructor
+  · intro h
+    rcases AbsoluteValue.isEquiv_iff_exists_rpow_eq.mp h with ⟨α, hα, hpow⟩
+    refine ⟨α, hα, ?_⟩
+    intro x
+    exact (congrFun hpow x).symm
+  · rintro ⟨α, hα, hpow⟩
+    refine AbsoluteValue.isEquiv_iff_exists_rpow_eq.mpr ?_
+    refine ⟨α, hα, funext ?_⟩
+    intro x
+    exact (hpow x).symm
+
+end Definition_01_06
+
+end Chapter1
+end SutherlandNumberTheoryLecture1

--- a/progress/2026-04-20T19-30-10Z.md
+++ b/progress/2026-04-20T19-30-10Z.md
@@ -1,0 +1,21 @@
+## Accomplished
+- Claimed repair issue `#159`, verified that PR `#94` was stale because its Stage 3.1 setup deliverables were already present on `master`, and retired the obsolete `#94`/`#97` stacks by closing PRs `#94` and `#97` plus their satisfied source issues `#93` and `#96`.
+- Claimed repair issue `#158` and replayed the live `Chapter1/01_06_Definition` scaffold onto current `master` by adding [01_06_Definition.lean](/home/kim/Sutherland-NumberTheory-Lecture1-draft3/worktrees/ac4ea2c1/SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean:1), importing it from [Chapter1.lean](/home/kim/Sutherland-NumberTheory-Lecture1-draft3/worktrees/ac4ea2c1/SutherlandNumberTheoryLecture1/Chapter1.lean:1), and advancing the matching `progress/status.json` entry to `scaffolded`.
+- Ran `lake exe cache get` and `lake build`; the repaired `01_06` scaffold builds successfully on top of the cleaned opening-batch base.
+- Ran `coordination check-blocked` after closing the stale dependency issues; this already unblocked `#104`, `#105`, `#113`, `#117`, `#121`, `#123`, and `#134`.
+
+## Current frontier
+- The working tree contains the repaired `01_06` scaffold on branch `agent/ac4ea2c1`; the remaining publication steps are to retire obsolete PR `#103`, commit the repair, and open a replacement PR that supersedes `#103` while closing source issue `#100`.
+- `#118` and `#120` are still blocked only because issue `#100` remains open behind the old conflicted PR; `#106` still additionally depends on `#105`.
+
+## Overall project progress
+- Logical pages `1` through `7` remain fully transcribed, structured, and blobbed, and all Chapter 1 blobs remain through Stage `2.6`.
+- Stage `3.1` opening-batch setup is now reflected accurately in GitHub state: the setup issue `#93` and the base absolute-value issue `#96` are closed because their content is already on `master`.
+- Stage `3.1` scaffolding is now live on `master` for `Chapter1/01_02_Definition` and `Chapter1/01_03_Example`, with `Chapter1/01_06_Definition` repaired locally and ready to publish as the next landing.
+
+## Next step
+- Close PR `#103`, publish the repaired `01_06` branch as the replacement PR for issue `#100`, and enable auto-merge.
+- After that PR lands, rerun `coordination check-blocked`; `#118` (review `01_06`) and `#120` (`01_06a_Discussion`) should become executable immediately, while `#106` will also be closer but still waits on `#105`.
+
+## Blockers
+- None for the repaired `01_06` scaffold itself; publication is the only remaining step.

--- a/progress/status.json
+++ b/progress/status.json
@@ -173,10 +173,10 @@
     "notes": "Stage 2.6 attached blobs/Chapter1/01_05_Proof.refs.md, centering `FiniteField.pow_card` and the small follow-up lemmas needed to complete the finite-field argument."
   },
   "Chapter1/01_06_Definition": {
-    "status": "references_attached",
+    "status": "scaffolded",
     "last_updated": "2026-04-20",
-    "issue": "#82",
-    "notes": "Stage 2.6 attached blobs/Chapter1/01_06_Definition.refs.md, pointing directly to `AbsoluteValue.IsEquiv` and the matching lecture/Serre references."
+    "issue": "#100",
+    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean by identifying the book's equivalent-absolute-value definition with `AbsoluteValue.IsEquiv` and exposing the `|x|' = |x|^α` phrasing as `isEquiv_iff_exists_forall_rpow_eq`."
   },
   "Chapter1/01_06a_Discussion": {
     "status": "references_attached",


### PR DESCRIPTION
Closes #158
Closes #100

Supersedes obsolete conflicted PR #103 after replaying the `Chapter1/01_06_Definition` scaffold onto current `master`.

## Summary
- add `SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean` as the Stage 3.1 scaffold for Definition 1.6
- import `01_06_Definition` from the Chapter 1 spine and advance `Chapter1/01_06_Definition` to `scaffolded` in `progress/status.json`
- record the stale-stack cleanup (`#94`, `#97`) and the repaired `01_06` handoff in `progress/2026-04-20T19-30-10Z.md`

## Verification
- `lake exe cache get`
- `lake build`

## Unblocked After Merge
- `#118` should become executable immediately
- `#120` should become executable immediately
- `#106` will still also depend on `#105`
