### PR TITLE
Review scaffolding for Chapter1/01_02_Definition

### DIFF
--- a/progress/2026-04-20T19-39-18Z.md
+++ b/progress/2026-04-20T19-39-18Z.md
@@ -1,0 +1,20 @@
+## Accomplished
+- Claimed issue `#117` and completed the Stage `3.2` scaffolding review for `Chapter1/01_02_Definition`.
+- Audited `blobs/Chapter1/01_02_Definition.md` against `SutherlandNumberTheoryLecture1/Chapter1/01_02_Definition.lean` and confirmed full claim coverage: axioms (1)-(3) are represented by the recalled Mathlib `AbsoluteValue` definition, and axiom (4) is represented by `isNonarchimedean_iff`.
+- Ran `lake exe cache get` for the session and verified the import chain with `lake build`.
+- Updated `progress/status.json` so `Chapter1/01_02_Definition` is now `definition_verified`.
+
+## Current frontier
+- `Chapter1/01_02_Definition` is ready for later Stage `3.3` missing-claims audit.
+- The next oldest unclaimed review/scaffolding frontier remains the opening-batch items, with `#121` (`Chapter1/01_00_Introduction`) and `#123` (review of opening-batch non-formalizable assessments) still available.
+
+## Overall project progress
+- Stage `1.6` structure analysis is complete for pages 1 through 7.
+- Stage `3.1` scaffolding has landed for `Chapter1/01_02_Definition` and `Chapter1/01_03_Example`.
+- Stage `3.2` review has now advanced `Chapter1/01_02_Definition` from `scaffolded` to `definition_verified`.
+
+## Next step
+- Prefer the next oldest unclaimed opening-batch item: scaffold `Chapter1/01_00_Introduction` (`#121`) or review the opening-batch `non_formalizable` assessments (`#123`).
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -137,10 +137,10 @@
     }
   },
   "Chapter1/01_02_Definition": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-20",
-    "issue": "#96",
-    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_02_Definition.lean by recalling Mathlib's `AbsoluteValue` for axioms (1)-(3) and isolating the nonarchimedean strengthening as `isNonarchimedean_iff`."
+    "issue": "#117",
+    "notes": "Stage 3.2 review passed for SutherlandNumberTheoryLecture1/Chapter1/01_02_Definition.lean: the lecture's absolute-value axioms (1)-(3) are covered directly by Mathlib's bundled `AbsoluteValue`, the nonarchimedean strengthening is exposed explicitly by `isNonarchimedean_iff`, no bridge theorem beyond the review note was needed because the recalled definition unfolds to the lecture wording, and no definition-level `sorry` was found."
   },
   "Chapter1/01_03_Example": {
     "status": "definition_verified",


### PR DESCRIPTION
Closes #117

## Stage 3.2 Coverage Audit
- [x] Enumerate claims
  Claim 1: Definition 1.2 introduces the concept of an absolute value on a field `k`, i.e. a map `|.| : k → ℝ≥0` satisfying positive-definiteness, multiplicativity, and the triangle inequality.
  Claim 2: The blob introduces the strengthened nonarchimedean condition `|x + y| ≤ max(|x|, |y|)` and names absolute values satisfying it as nonarchimedean.
  Claim 3: The blob classifies absolute values failing condition (4) as archimedean.
- [x] Map each claim to Lean
  Claim 1 is covered by the recalled Mathlib declaration `AbsoluteValue k ℝ`; the review accepts the recall because the lecture definition unfolds directly to Mathlib's bundled structure and no wrapper synonym was introduced.
  Claim 2 is covered by `SutherlandNumberTheoryLecture1.Chapter1.isNonarchimedean_iff` in `SutherlandNumberTheoryLecture1/Chapter1/01_02_Definition.lean`.
  Claim 3 is covered implicitly by Claim 2 together with the blob text's complementary naming convention; no separate Lean declaration is needed yet because the file introduces only the strengthened predicate, not a new data structure.
- [x] Flag gaps
  No coverage gaps were found in this blob.
- [x] Check non-trivial equivalences
  No additional bridge theorem was required for Claim 1 because the review determined that the lecture wording for axioms (1)-(3) unfolds directly to Mathlib's `AbsoluteValue`. Claim 2 has an explicit bridge theorem: `isNonarchimedean_iff`.
- [x] Check definition integrity
  No definition-level `sorry` or other sorried data was found.

## Verification
- Ran `lake exe cache get`
- Ran `lake build`

## Status
- Updated `progress/status.json` to mark `Chapter1/01_02_Definition` as `definition_verified`.
- Added `progress/2026-04-20T19-39-18Z.md`.

Session: `17b13b57-fcbb-42c6-9379-4ad898db0432`
