### PR TITLE
Review scaffolding for Chapter1/01_04_Lemma

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_04_Lemma.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_04_Lemma.lean
@@ -26,11 +26,32 @@ theorem natCast_le_one_of_isNonarchimedean (abv : AbsoluteValue k ℝ)
   intro n
   simpa using IsNonarchimedean.apply_natCast_le_one_of_isNonarchimedean (f := abv) hna (n := n)
 
+/-- The book phrases the natural-number bound for positive integers `n ≥ 1`. -/
+theorem natCast_pos_le_one_of_isNonarchimedean (abv : AbsoluteValue k ℝ)
+    (hna : IsNonarchimedean abv) :
+    ∀ n : ℕ, 0 < n → abv n ≤ 1 := by
+  intro n hn
+  exact natCast_le_one_of_isNonarchimedean abv hna n
+
 /-- The converse direction is the book-specific bridge deferred to the proof stage. -/
 theorem isNonarchimedean_of_natCast_le_one (abv : AbsoluteValue k ℝ)
     (h_nat : ∀ n : ℕ, abv n ≤ 1) :
     IsNonarchimedean abv := by
   sorry
+
+/-- Lemma 1.4 in the lecture's original `n ≥ 1` form. -/
+theorem isNonarchimedean_iff_natCast_pos_le_one (abv : AbsoluteValue k ℝ) :
+    IsNonarchimedean abv ↔ ∀ n : ℕ, 0 < n → abv n ≤ 1 := by
+  constructor
+  · exact natCast_pos_le_one_of_isNonarchimedean abv
+  · intro h_pos
+    apply isNonarchimedean_of_natCast_le_one
+    intro n
+    cases n with
+    | zero =>
+        simpa only [Nat.cast_zero, map_zero] using (show (0 : ℝ) ≤ 1 by norm_num)
+    | succ m =>
+        exact h_pos (Nat.succ m) (Nat.succ_pos m)
 
 /-- Lemma 1.4: an absolute value is nonarchimedean iff
 all natural-number sums have value at most `1`. -/

--- a/progress/2026-04-21T01-56-27Z.md
+++ b/progress/2026-04-21T01-56-27Z.md
@@ -1,0 +1,18 @@
+## Accomplished
+- Claimed issue `#122` and completed the Stage 3.2 review for `Chapter1/01_04_Lemma`.
+- Reviewed `blobs/Chapter1/01_04_Lemma.md` against `SutherlandNumberTheoryLecture1/Chapter1/01_04_Lemma.lean`; the blob has one formalizable claim, and it is now represented both by the existing stronger all-`ℕ` helper and by a new lecture-exact `n ≥ 1` iff theorem.
+- Kept the converse bridge explicit as `isNonarchimedean_of_natCast_le_one`, updated `progress/status.json` to `definition_verified`, and verified the project with `lake build`.
+
+## Current frontier
+- `Chapter1/01_04_Lemma` is ready for the Stage 3.3 missing-claims audit once the sibling review issues in `#126` and `#167` are also closed.
+
+## Overall project progress
+- Phase 1 and Phase 2 artifacts for the current Chapter 1 slice remain in place.
+- Stage 3.2 review work has advanced: `Chapter1/01_04_Lemma` now joins the already-reviewed opening blobs as a verified scaffolded item.
+- Stage 3.3 remains partially blocked on the remaining unreviewed blobs named in issue `#171`.
+
+## Next step
+- Review `#126` for `Chapter1/01_00_Introduction`, then `#167` for `Chapter1/01_29a_Bibliography`, so `#171` can proceed on the next audit batch.
+
+## Blockers
+- `#171` still depends on review completion for `#126` and `#167`.

--- a/progress/status.json
+++ b/progress/status.json
@@ -309,10 +309,10 @@
     }
   },
   "Chapter1/01_04_Lemma": {
-    "status": "scaffolded",
-    "last_updated": "2026-04-20",
-    "issue": "#104",
-    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_04_Lemma.lean with the lecture's full nonarchimedean iff criterion, using Mathlib for the forward direction and isolating the converse as `isNonarchimedean_of_natCast_le_one` for later proof work."
+    "status": "definition_verified",
+    "last_updated": "2026-04-21",
+    "issue": "#122",
+    "notes": "Stage 3.2 reviewed SutherlandNumberTheoryLecture1/Chapter1/01_04_Lemma.lean against the blob's single iff claim, kept the explicit converse bridge `isNonarchimedean_of_natCast_le_one`, and added the lecture-exact `n ≥ 1` criterion as `isNonarchimedean_iff_natCast_pos_le_one` alongside the stronger all-`ℕ` helper."
   },
   "Chapter1/01_04_Proof": {
     "status": "references_attached",


### PR DESCRIPTION
## Summary
- review `Chapter1/01_04_Lemma` against its blob and keep the converse bridge explicit
- add a lecture-exact `n ≥ 1` iff theorem alongside the stronger all-`ℕ` helper
- mark the blob `definition_verified` and record the handoff in `progress/2026-04-21T01-56-27Z.md`

## Stage 3.2 coverage audit
- Blob claim 1: an absolute value on a field is nonarchimedean iff `|1 + \cdots + 1| ≤ 1` for all integers `n ≥ 1`.
  Lean coverage:
  `SutherlandNumberTheoryLecture1.Chapter1.natCast_pos_le_one_of_isNonarchimedean`
  `SutherlandNumberTheoryLecture1.Chapter1.isNonarchimedean_of_natCast_le_one`
  `SutherlandNumberTheoryLecture1.Chapter1.isNonarchimedean_iff_natCast_pos_le_one`
  `SutherlandNumberTheoryLecture1.Chapter1.isNonarchimedean_iff_natCast_le_one`
- Mathlib anchor used for the forward direction:
  `IsNonarchimedean.apply_natCast_le_one_of_isNonarchimedean`
- Coverage result: clean after review. The only gap left is the intentional theorem-level `sorry` in the converse bridge, which is appropriate for Stage 3.1/3.2 and not a definition-level blocker.

## Verification
- `lake exe cache get`
- `lake build`

Closes #122
