### PR TITLE
Review scaffolding for Chapter1/01_00_Introduction

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_00_Introduction.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_00_Introduction.lean
@@ -22,6 +22,19 @@ section Introduction_01_00
 
 variable (K : Type*) [Field K]
 
+/-- The lecture's ambient starting ring `ℤ` is a principal ideal domain. -/
+theorem int_isPID : IsPrincipalIdealRing ℤ := by
+  infer_instance
+
+/-- The lecture's field of fractions of `ℤ` is Mathlib's `ℚ`. -/
+theorem int_fractionRing_isRat : IsFractionRing ℤ ℚ := by
+  infer_instance
+
+/-- Quotienting `ℤ` by the principal ideal `(p)` gives the prime field `𝔽_p`. -/
+def int_quotient_span_nat_equiv_zmod (p : ℕ) :
+    (ℤ ⧸ Ideal.span ({(p : ℤ)} : Set ℤ)) ≃+* ZMod p := by
+  exact Int.quotientSpanNatEquivZMod p
+
 /-- In characteristic zero, the lecture's prime field is `ℚ`. -/
 theorem charZero_contains_rat [CharZero K] : Nonempty (Algebra ℚ K) := by
   exact ⟨inferInstance⟩
@@ -46,6 +59,17 @@ theorem quotient_by_irreducible_isNumberField (f : Polynomial ℚ) [Fact (Irredu
     NumberField (AdjoinRoot f) := by
   infer_instance
 
+/-- The lecture's presentation of number fields uses that `ℚ[X]` is a PID. -/
+theorem rational_polynomial_isPID : IsPrincipalIdealRing (Polynomial ℚ) := by
+  infer_instance
+
+/-- Over a field, irreducible polynomials generate maximal ideals, matching the quotient
+presentation used for the lecture's number-field examples. -/
+theorem irreducible_generates_maximal_ideal_over_rat
+    (f : Polynomial ℚ) [Fact (Irreducible f)] :
+    (Ideal.span ({f} : Set (Polynomial ℚ))).IsMaximal := by
+  sorry
+
 variable (Fq F : Type*) [Field Fq] [Field F] [Algebra (RatFunc Fq) F]
 
 /-- Mathlib's `FunctionField` predicate packages the lecture's definition of a global function
@@ -69,6 +93,13 @@ theorem quotientByIrreducibleOverFunctionFieldBaseField
 finite fields. We isolate that claim here for later proof refinement. -/
 theorem quotient_by_irreducible_over_finite_field_isFinite
     [Finite Fq] (f : Polynomial Fq) [Fact (Irreducible f)] : Finite (AdjoinRoot f) := by
+  sorry
+
+/-- The lecture sharpens the previous residue-field claim by identifying the quotient with a
+finite field of size `q^d`, where `q = |F_q|` and `d = deg f`. -/
+theorem quotient_by_irreducible_over_finite_field_card
+    [Finite Fq] (f : Polynomial Fq) [Fact (Irreducible f)] :
+    Nat.card (AdjoinRoot f) = Nat.card Fq ^ f.natDegree := by
   sorry
 
 end Introduction_01_00

--- a/progress/2026-04-21T01-57-32Z_b01e74ff.md
+++ b/progress/2026-04-21T01-57-32Z_b01e74ff.md
@@ -1,0 +1,20 @@
+## Accomplished
+- Claimed issue `#126` and completed the Stage 3.2 review for `Chapter1/01_00_Introduction`.
+- Tightened `SutherlandNumberTheoryLecture1/Chapter1/01_00_Introduction.lean` so the blob's review-critical claims map to explicit declarations: `ℤ` as a PID, `ℚ` as its fraction field, the quotient `ℤ/(p)` as `𝔽_p`, the `ℚ[X]` PID/maximal-ideal presentation of number fields, and the finite-field residue-cardinality statement for `F_q[t]/(f)`.
+- Updated `progress/status.json` to mark `Chapter1/01_00_Introduction` as `definition_verified`.
+
+## Current frontier
+- `Chapter1/01_04_Lemma` and `Chapter1/01_29a_Bibliography` still need their Stage 3.2 reviews merged before the queued Stage 3.3 audit issue `#171` can run cleanly.
+- `Chapter1/01_07_Definition` review issue `#124` remains a separate unblocked gateway for the opening-batch theorem stream.
+
+## Overall project progress
+- Phase 1 and Phase 2 artifacts for the current Chapter 1 slice remain in place.
+- Stage 3.1 scaffolding is active across the Chapter 1 opening, valuation, and integrality streams.
+- Stage 3.2 review now has `Chapter1/01_00_Introduction` cleared; the opening-batch Stage 3.3 queue is still waiting on the remaining review blockers named above.
+
+## Next step
+- Complete the remaining review blockers for `#171`, with `#167` or the still-open `Chapter1/01_04_Lemma` review path as the highest-value follow-up.
+- In parallel with that audit path, `#124` is the next clean review issue if the goal is to advance the opening-batch theorem stream.
+
+## Blockers
+- `#171` is still blocked on the remaining review completions for `Chapter1/01_04_Lemma` and `Chapter1/01_29a_Bibliography` (and any merge lag associated with them).

--- a/progress/status.json
+++ b/progress/status.json
@@ -42,10 +42,10 @@
     "notes": "Stage 1.6 structure analysis assigned every line on logical pages 1 through 7 to ordered items in items.json; page 7 covers Definition 1.26, Remark 1.27, Proposition 1.28 with proof, Example 1.29, and the references bibliography."
   },
   "Chapter1/01_00_Introduction": {
-    "status": "scaffolded",
-    "last_updated": "2026-04-20",
-    "issue": "#121",
-    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_00_Introduction.lean by packaging the introduction's formalizable claims as explicit declarations: characteristic-zero and characteristic-p prime-field embeddings, the number-field/irreducible-quotient framing via `NumberField` and `AdjoinRoot`, the `F_q[t]` PID/residue-field analogy, and the definition-level `FunctionField` finite-extension statement. The local-field/completion survey remains deferred commentary in the file rather than a fake placeholder theorem.",
+    "status": "definition_verified",
+    "last_updated": "2026-04-21",
+    "issue": "#126",
+    "notes": "Stage 3.2 review for issue #126 tightened SutherlandNumberTheoryLecture1/Chapter1/01_00_Introduction.lean so the introduction's blob-level claims map to explicit declarations: `ℤ` as a PID with fraction field `ℚ`, the quotient `ℤ/(p)` as `𝔽_p`, the prime-field embeddings by characteristic, the `ℚ[X]` PID / irreducible-maximal-ideal presentation of number fields, the `F_q[t]` PID analogy, and the function-field finite-extension statement. The completion/local-field survey sentence remains intentionally deferred as Stage 3.1's previously recorded `formalizable_later` claim rather than an unreviewed coverage gap.",
     "stage3_1_decision": {
       "decision": "formalizable",
       "claims": [


### PR DESCRIPTION
Closes #126

## Stage 3.2 Coverage Audit
- Claim: The introduction packages `ℤ` as the ambient PID with fraction field `ℚ`.
  Lean: `int_isPID`, `int_fractionRing_isRat` in `SutherlandNumberTheoryLecture1/Chapter1/01_00_Introduction.lean`.
- Claim: For prime characteristic, the prime-field side of the introduction is `ℤ/(p) = 𝔽_p`, and every field contains `ℚ` or `𝔽_p` according to characteristic.
  Lean: `int_quotient_span_nat_equiv_zmod`, `charZero_contains_rat`, `charP_contains_zmod`.
- Claim: Number fields are finite extensions of `ℚ`, and the lecture's quotient presentation uses irreducible polynomials over `ℚ[X]`.
  Lean: `numberField_isFiniteExtension`, `quotientByIrreducibleField`, `quotient_by_irreducible_isNumberField`, `rational_polynomial_isPID`, `irreducible_generates_maximal_ideal_over_rat`.
- Claim: The `F_q[t]` side of the analogy is a PID, and quotients by irreducibles give finite residue fields of size `q^d`.
  Lean: `polynomial_over_field_isPID`, `quotientByIrreducibleOverFunctionFieldBaseField`, `quotient_by_irreducible_over_finite_field_isFinite`, `quotient_by_irreducible_over_finite_field_card`.
- Claim: Global function fields are finite extensions of `F_q(t)`.
  Lean: `globalFunctionField_isFiniteExtension`.
- Claim: The final completion/local-field survey sentence is mathematical but deferred by the Stage 3.1 decision as `formalizable_later`, so it is not a Stage 3.2 coverage gap for this scaffold.
  Lean: review disposition recorded in `progress/status.json` for `Chapter1/01_00_Introduction`.

## Review Result
- No definition-level `sorry` was introduced.
- The only remaining `sorry`s are theorem-level placeholders in explicit bridge statements, which is valid for Stage 3.2.
- `progress/status.json` advances `Chapter1/01_00_Introduction` to `definition_verified`.

## Verification
- `lake exe cache get`
- `lake build`
