### PR TITLE
Review Chapter1/01_07_Definition

### DIFF
--- a/progress/2026-04-21T02-20-11Z_825dc923.md
+++ b/progress/2026-04-21T02-20-11Z_825dc923.md
@@ -1,0 +1,21 @@
+## Accomplished
+- Claimed issue `#124` and completed the Stage 3.2 review for `Chapter1/01_07_Definition`.
+- Audited `blobs/Chapter1/01_07_Definition.md` against `SutherlandNumberTheoryLecture1/Chapter1/01_07_Definition.lean` and confirmed the lecture's explicit `v_p(0) = ∞` and `|0|_p = 0` conventions are represented by declarations, not left in prose.
+- Ran `lake exe cache get` for the session and verified the repository with a full `lake build`.
+- Updated `progress/status.json` to mark `Chapter1/01_07_Definition` as `definition_verified`.
+
+## Current frontier
+- The next opening-batch theorem scaffolds `#106` (`Chapter1/01_08_Theorem`) and `#111` (`Chapter1/01_09_Theorem`) are now cleaner to execute because the Stage 3.2 gateway review for `Chapter1/01_07_Definition` is done.
+- The separate Stage 3.2 review `#167` for `Chapter1/01_29a_Bibliography` still stands between the queue and the bundled Stage 3.3 audit issue `#171`.
+
+## Overall project progress
+- Phase 1 and Phase 2 artifacts remain in place for the active Chapter 1 slice.
+- Stage 3.1 scaffolding for the Chapter 1 opening batch is partially built out through `Chapter1/01_07_Definition`, and Stage 3.2 has now verified `Chapter1/01_00_Introduction`, `Chapter1/01_04_Lemma`, and `Chapter1/01_07_Definition`.
+- The opening-batch absolute-value stream is ready to advance into the theorem scaffolds rather than revisiting this definition.
+
+## Next step
+- Execute `#106` to scaffold `Chapter1/01_08_Theorem`, since the `p`-adic-definition review gate is now cleared and that theorem is the next low-friction downstream item.
+- If the goal is to unblock the pending Stage 3.3 audit bundle `#171`, complete `#167` for `Chapter1/01_29a_Bibliography` next instead.
+
+## Blockers
+- `#171` still depends on `#167` for the bibliography review before that audit batch can be completed.

--- a/progress/status.json
+++ b/progress/status.json
@@ -368,10 +368,10 @@
     }
   },
   "Chapter1/01_07_Definition": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-21",
-    "issue": "#105",
-    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_07_Definition.lean with a real `WithTop ℤ` wrapper for the lecture's convention `v_p(0) = ∞`, together with explicit zero/nonzero declarations relating the induced absolute value to `Rat.AbsoluteValue.padic`, `padicNorm`, and `padicValRat`."
+    "issue": "#124",
+    "notes": "Stage 3.2 review for issue #124 confirmed that SutherlandNumberTheoryLecture1/Chapter1/01_07_Definition.lean covers the blob's explicit claims with declarations: `padicValuation` gives the lecture's `WithTop ℤ` wrapper with `v_p(0) = ∞`, `padicValuation_of_ne_zero` exposes the nonzero `padicValRat` branch, `padicAbsoluteValue_apply_zero` and `padicAbsoluteValue_apply_of_ne_zero` make the zero and nonzero formulas for `|·|_p` explicit, and `padicAbsoluteValue_isNonarchimedean` records the nonarchimedean property. No review repair was needed."
   },
   "Chapter1/01_08_Theorem": {
     "status": "references_attached",


### PR DESCRIPTION
## Summary
- complete the Stage 3.2 review for `Chapter1/01_07_Definition`
- confirm the existing scaffold covers the blob's explicit valuation and zero-convention claims without code changes
- promote `Chapter1/01_07_Definition` to `definition_verified` and record the handoff

## Stage 3.2 Coverage Audit
- Claim: for a prime `p`, the lecture's `p`-adic valuation on `ℚ` is the exponent of `p` in the nonzero rational factorization.
  Lean mapping: `SutherlandNumberTheoryLecture1.Chapter1.padicValuation_of_ne_zero` packages the nonzero branch directly in terms of `padicValRat`, which is Mathlib's exponent-of-`p` valuation on rationals.
- Claim: `v_p(0) = ∞`.
  Lean mapping: `SutherlandNumberTheoryLecture1.Chapter1.padicValuation` is a `WithTop ℤ` wrapper and `SutherlandNumberTheoryLecture1.Chapter1.padicValuation_zero` makes the zero convention explicit.
- Claim: the `p`-adic absolute value is `|x|_p := p^{-v_p(x)}` with `|0|_p = 0`.
  Lean mapping: `SutherlandNumberTheoryLecture1.Chapter1.padicAbsoluteValue_apply_zero` covers the zero case and `SutherlandNumberTheoryLecture1.Chapter1.padicAbsoluteValue_apply_of_ne_zero` covers the nonzero `p^{-v_p(x)}` formula via `padicNorm` / `Rat.AbsoluteValue.padic`.
- Claim: the packaged `p`-adic absolute value is nonarchimedean.
  Lean mapping: `SutherlandNumberTheoryLecture1.Chapter1.padicAbsoluteValue_isNonarchimedean` imports the Mathlib nonarchimedean property explicitly.

## Review Outcome
- no definition-level `sorry` found in `SutherlandNumberTheoryLecture1/Chapter1/01_07_Definition.lean`
- no missing bridge lemma was needed: the zero convention and the nonzero formula are already explicit declarations
- `progress/status.json` now records `Chapter1/01_07_Definition` as `definition_verified`

## Verification
- `lake exe cache get`
- `lake build`
