### PR TITLE
Review Chapter1/01_06_Definition

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean
@@ -31,6 +31,16 @@ theorem isEquiv_iff_exists_rpow_eq_pointwise (abv abv' : AbsoluteValue k ℝ) :
   · rintro ⟨α, hα, hpow⟩
     exact ⟨α, hα, funext hpow⟩
 
+/-- This is the lecture's `|x|' = |x|^α` phrasing written verbatim. -/
+theorem isEquiv_iff_exists_rpow_eq_textbook (abv abv' : AbsoluteValue k ℝ) :
+    abv.IsEquiv abv' ↔ ∃ α : ℝ, 0 < α ∧ ∀ x : k, abv' x = abv x ^ α := by
+  rw [isEquiv_iff_exists_rpow_eq_pointwise]
+  constructor
+  · rintro ⟨α, hα, hpow⟩
+    exact ⟨α, hα, fun x => (hpow x).symm⟩
+  · rintro ⟨α, hα, hpow⟩
+    exact ⟨α, hα, fun x => (hpow x).symm⟩
+
 end Definition_01_06
 
 end Chapter1

--- a/progress/2026-04-21T03-00-32Z_23b9fe64.md
+++ b/progress/2026-04-21T03-00-32Z_23b9fe64.md
@@ -1,0 +1,21 @@
+## Accomplished
+- Claimed and completed issue `#118`, the Stage 3.2 review for `Chapter1/01_06_Definition`.
+- Audited `blobs/Chapter1/01_06_Definition.md` against `SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean` and confirmed the blob has one mathematical claim: equivalence of absolute values via a positive real exponent.
+- Added `isEquiv_iff_exists_rpow_eq_textbook` so the Lean file now states the lecture's exact `|x|' = |x|^α` wording explicitly, in addition to the pointwise bridge from `AbsoluteValue.isEquiv_iff_exists_rpow_eq`.
+- Updated `progress/status.json` so `Chapter1/01_06_Definition` is now `definition_verified`.
+- Ran `lake exe cache get` and `lake build`; the build succeeded.
+
+## Current frontier
+- `Chapter1/01_06_Definition` has passed Stage 3.2 and no longer blocks downstream scaffolding/review work in the absolute-value opening batch.
+
+## Overall project progress
+- The Chapter 1 opening batch now has Stage 3.2 verification recorded for `Chapter1/01_06_Definition` and `Chapter1/01_07_Definition`.
+- Remaining visible work in this local queue is still centered on unresolved Stage 3.1 scaffolding items such as `Chapter1/01_06a_Discussion`, `Chapter1/01_08_Proof`, `Chapter1/01_04_Proof`, and `Chapter1/01_09_Theorem`.
+- Repository build health is unchanged apart from this review pass: `lake build` still reports only the pre-existing theorem-level `sorry` warnings in `Chapter1/01_00_Introduction` and `Chapter1/01_04_Lemma`.
+
+## Next step
+- Take `#120` (`Chapter1/01_06a_Discussion`) next if the goal is to close the remaining gap between the equivalence definition and the `p`-adic/Ostrowski material.
+- Alternatively, if theorem/proof momentum is preferred, continue with the Ostrowski queue once its dependencies are merged, starting from `#108`.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -402,10 +402,10 @@
     "notes": "Stage 2.6 attached blobs/Chapter1/01_05_Proof.refs.md, centering `FiniteField.pow_card` and the small follow-up lemmas needed to complete the finite-field argument."
   },
   "Chapter1/01_06_Definition": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-21",
-    "issue": "#100",
-    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean by recalling Mathlib's `AbsoluteValue.IsEquiv` and adding an explicit pointwise bridge from `AbsoluteValue.isEquiv_iff_exists_rpow_eq` to the lecture's `|x|' = |x|^α` formulation."
+    "issue": "#118",
+    "notes": "Stage 3.2 review for issue #118 confirmed that SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean covers the blob's equivalence claim with explicit Lean bridges in both orientations: `isEquiv_iff_exists_rpow_eq_pointwise` records the pointwise power equation from `AbsoluteValue.isEquiv_iff_exists_rpow_eq`, and `isEquiv_iff_exists_rpow_eq_textbook` matches the lecture's exact `|x|' = |x|^α` wording. No definition-level sorries or coverage gaps remain."
   },
   "Chapter1/01_06a_Discussion": {
     "status": "references_attached",


### PR DESCRIPTION
## Summary
- review `blobs/Chapter1/01_06_Definition.md` against `SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean`
- add an explicit theorem for the textbook-oriented `|x|' = |x|^α` wording
- advance `Chapter1/01_06_Definition` to `definition_verified` and record the handoff

## Stage 3.2 coverage audit
- [x] Enumerate claims
  Claim 1: Two absolute values on the same field are equivalent iff there exists `α > 0` such that `|x|' = |x|^α` for all `x`.
- [x] Map claims to Lean
  Claim 1 is covered by `isEquiv_iff_exists_rpow_eq_textbook`, with `isEquiv_iff_exists_rpow_eq_pointwise` retaining the direct bridge from `AbsoluteValue.isEquiv_iff_exists_rpow_eq`.
- [x] Flag gaps
  No coverage gaps remain for this blob.
- [x] Check non-trivial equivalences
  The file now contains an explicit bridge in both orientations, including the lecture's exact `|x|' = |x|^α` phrasing.
- [x] Check definition integrity
  No definition-level `sorry` or TODO markers are present in `SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean`.

## Verification
- `lake exe cache get`
- `lake build`
  Build succeeds; only pre-existing theorem-level `sorry` warnings remain in `Chapter1/01_00_Introduction` and `Chapter1/01_04_Lemma`.

Closes #118.
