### PR TITLE
Repair PR #165 Chapter1/01_10_Definition conflicts

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1.lean
@@ -15,6 +15,7 @@ import SutherlandNumberTheoryLecture1.Chapter1.«01_07_Definition»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_08_Theorem»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_08_Proof»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_09_Theorem»
+import SutherlandNumberTheoryLecture1.Chapter1.«01_10_Definition»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_17_Definition»
 
 /-!

--- a/SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean
@@ -1,0 +1,98 @@
+import Mathlib
+import SutherlandNumberTheoryLecture1.Chapter1.«01_02_Definition»
+
+/-!
+# Definition 1.10: Valuations, valuation rings, and DVRs
+
+The lecture presents a valuation on a field `k` as a homomorphism `kˣ → ℝ`
+satisfying the additive nonarchimedean inequality, then extends it to
+`k → ℝ ∪ {∞}` by sending `0` to `∞`. Mathlib already packages that extended
+object as `AddValuation k (WithTop ℝ)`, so this file records the lecture's
+definition directly in terms of the bundled additive valuation API.
+
+The derived nonarchimedean absolute value `|x|ᵥ = c ^ v(x)` for `0 < c < 1`
+is kept as an explicit declaration rather than prose-only commentary. The proof
+details are left at theorem level for later stages.
+
+For the valuation ring and DVR clauses, the lecture's constructions match
+Mathlib's bundled objects:
+
+- `v.toValuation.valuationSubring` is the valuation ring attached to `v`
+- `IsDiscreteValuationRing` is the bundled DVR predicate
+
+The lecture's normalization "the value group is equal to `ℤ`" is recorded as a
+set-level predicate on the real values taken on units; Mathlib's more invariant
+discreteness API is `Valuation.IsRankOneDiscrete`.
+-/
+
+namespace SutherlandNumberTheoryLecture1
+namespace Chapter1
+
+section Definition_01_10
+
+variable {k : Type*} [Field k]
+
+/-- The lecture's real-valued valuation is Mathlib's bundled additive valuation. -/
+abbrev RealValuation (k : Type*) [Field k] := AddValuation k (WithTop ℝ)
+
+/-- The multiplicative valuation underlying the bundled additive valuation. -/
+noncomputable abbrev asValuation (v : RealValuation k) :
+    Valuation k (Multiplicative (WithTop ℝ)ᵒᵈ) :=
+  AddValuation.toValuation v
+
+/-- The real value taken by the valuation on a nonzero element, packaged via a unit. -/
+noncomputable def valueOfUnit (v : RealValuation k) (u : kˣ) : ℝ :=
+  (v (u : k)).untop ((v.ne_top_iff).2 u.ne_zero)
+
+/-- The lecture's value group, viewed as the set of real values attained on `kˣ`. -/
+def valueGroup (v : RealValuation k) : Set ℝ :=
+  Set.range (valueOfUnit v)
+
+/-- The lecture normalizes a discrete valuation by requiring the value group to be `ℤ`. -/
+def IsDiscrete (v : RealValuation k) : Prop :=
+  valueGroup v = Set.range (fun n : ℤ => (n : ℝ))
+
+/-- The lecture's valuation ring is Mathlib's `valuationSubring`
+attached to the bundled valuation. -/
+noncomputable abbrev valuationSubring (v : RealValuation k) : ValuationSubring k :=
+  (asValuation v).valuationSubring
+
+/-- The lecture's construction `|x|ᵥ = c ^ v(x)` for `0 < c < 1`. -/
+noncomputable def derivedAbsoluteValue (v : RealValuation k) (c : ℝ) (hc0 : 0 < c) (hc1 : c < 1) :
+    AbsoluteValue k ℝ := by
+  classical
+  refine
+    { toFun := fun x => if hx : x = 0 then 0 else c ^ ((v x).untop ((v.ne_top_iff).2 hx))
+      map_mul' := by
+        intro x y
+        sorry
+      nonneg' := by
+        intro x
+        sorry
+      eq_zero' := by
+        intro x
+        sorry
+      add_le' := by
+        intro x y
+        sorry }
+
+/-- A valuation ring coming from a cyclic nontrivial value group is a DVR in Mathlib's sense. -/
+instance instIsDiscreteValuationRing (v : RealValuation k)
+    [IsCyclic (MonoidWithZeroHom.valueGroup (asValuation v))]
+    [Nontrivial (MonoidWithZeroHom.valueGroup (asValuation v))] :
+    IsDiscreteValuationRing (valuationSubring v) := by
+  change IsDiscreteValuationRing ((asValuation v).valuationSubring)
+  infer_instance
+
+/-- The lecture notes that a DVR cannot be a field. -/
+theorem valuationSubring_maximalIdeal_ne_bot (v : RealValuation k)
+    [IsCyclic (MonoidWithZeroHom.valueGroup (asValuation v))]
+    [Nontrivial (MonoidWithZeroHom.valueGroup (asValuation v))] :
+    IsLocalRing.maximalIdeal (valuationSubring v) ≠ ⊥ := by
+  exact IsLocalRing.isField_iff_maximalIdeal_eq.not.mp
+    (Valuation.valuationSubring_not_isField (asValuation v))
+
+end Definition_01_10
+
+end Chapter1
+end SutherlandNumberTheoryLecture1

--- a/progress/2026-04-21T03-30-41Z.md
+++ b/progress/2026-04-21T03-30-41Z.md
@@ -1,0 +1,19 @@
+## Accomplished
+- Claimed issue `#192` and replayed the `Chapter1/01_10_Definition` Stage 3.1 scaffold from conflicted PR `#165` onto current `master`.
+- Restored `SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean`, updated the Chapter 1 import spine, and advanced `Chapter1/01_10_Definition` to `scaffolded` in `progress/status.json`.
+- Adjusted the original replay slightly for the current Mathlib snapshot by proving the DVR non-field clause through `Valuation.valuationSubring_not_isField` and `IsLocalRing.isField_iff_maximalIdeal_eq`.
+- Ran `lake exe cache get` and `lake build`; the build now succeeds on the replacement branch.
+
+## Current frontier
+- `Chapter1/01_10_Definition` is rebuilt and ready to publish as the replacement for PR `#165`.
+- The file still intentionally contains theorem-level `sorry` placeholders inside `derivedAbsoluteValue`, which is acceptable for Stage `3.1`.
+
+## Overall project progress
+- Stage `3.1` Chapter 1 scaffolding continues to expand beyond the opening absolute-value tranche into the valuation/DVR vocabulary.
+- This repair reopens the blocked valuation stream, in particular the follow-on scaffold `#136` (`Chapter1/01_11_Definition`) and the review issue `#143`.
+
+## Next step
+- After this replacement PR lands, claim `#136` to scaffold `Chapter1/01_11_Definition` on top of the restored valuation vocabulary in `01_10_Definition`.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -498,10 +498,10 @@
     }
   },
   "Chapter1/01_10_Definition": {
-    "status": "references_attached",
+    "status": "scaffolded",
     "last_updated": "2026-04-20",
-    "issue": "#86",
-    "notes": "Stage 2.6 attached blobs/Chapter1/01_10_Definition.refs.md, linking the valuation and DVR definitions to `Valuation`, `AddValuation`, `Valuation.valuationSubring`, and the main course/reference sources."
+    "issue": "#134",
+    "notes": "Stage 3.1 scaffolded `SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean` by identifying the lecture's valuation with `AddValuation k (WithTop ℝ)`, recording the normalized discrete-value-group predicate on units, exposing `derivedAbsoluteValue`, and reusing `valuationSubring` plus `IsDiscreteValuationRing` for the valuation-ring/DVR clauses."
   },
   "Chapter1/01_10a_Discussion": {
     "status": "needs_definition",


### PR DESCRIPTION
Closes #192

Source issue: #134
Supersedes: #165

This replacement PR replays the Chapter1/01_10_Definition scaffold onto current master, restores the Chapter 1 import update, and reapplies the status transition to `scaffolded`.

Unblocks: #136 and #143

Session: `c1da5558-244d-47a3-8c17-ce41e47cfcde`

3cf8a5b fix: replay 01_10 definition scaffold for progress/2026-04-21T03-30-41Z.md
