### PR TITLE
Review Chapter1/01_06a_Discussion scaffolding

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_06a_Discussion.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_06a_Discussion.lean
@@ -10,6 +10,7 @@ This prose blob isolates two concrete pieces of mathematics that the lecture use
 before introducing the `p`-adic places:
 
 - the usual absolute value on `ℚ`, denoted `|·|_∞`, coming from the real place;
+- the existence of infinitely many absolute values on `ℚ` besides `|·|_∞`;
 - the unique expansion of a nonzero rational as a sign times finitely many prime
   powers with integer exponents.
 
@@ -35,6 +36,11 @@ theorem ratArchimedeanAbsoluteValue_apply (q : ℚ) :
 /-- The lecture emphasizes that the real place is archimedean, i.e. not nonarchimedean. -/
 theorem ratArchimedeanAbsoluteValue_not_isNonarchimedean :
     ¬ IsNonarchimedean ratArchimedeanAbsoluteValue := by
+  sorry
+
+/-- Besides the archimedean place `|·|_∞`, `ℚ` admits infinitely many other absolute values. -/
+theorem infinitelyMany_ratAbsoluteValues_not_isEquiv_archimedean :
+    Set.Infinite {f : AbsoluteValue ℚ ℝ | ¬ f.IsEquiv ratArchimedeanAbsoluteValue} := by
   sorry
 
 /-- Every nonzero rational has a unique signed prime-power expansion with finite support. -/

--- a/progress/2026-04-21T04-01-23Z_ec660d82.md
+++ b/progress/2026-04-21T04-01-23Z_ec660d82.md
@@ -1,0 +1,19 @@
+## Accomplished
+- Claimed review issue `#125` for `Chapter1/01_06a_Discussion` and performed the Stage `3.2` coverage audit against the blob and Lean scaffold.
+- Identified one real coverage gap in the scaffold: the blob's sentence asserting that `ℚ` has infinitely many absolute values besides `|.|_∞` had been deferred in Stage `3.1` but was still an uncovered mathematical claim for Stage `3.2`.
+- Added `infinitelyMany_ratAbsoluteValues_not_isEquiv_archimedean` to `SutherlandNumberTheoryLecture1/Chapter1/01_06a_Discussion.lean` so all three blob-level claims now have explicit Lean declarations.
+- Advanced `Chapter1/01_06a_Discussion` to `definition_verified` in `progress/status.json`.
+- Ran `lake exe cache get` and `lake build`; the build completed successfully.
+
+## Current frontier
+- Issue `#125` is ready to publish as a review PR with the explicit Stage `3.2` coverage audit in the PR body.
+
+## Overall project progress
+- Chapter 1 Stage `3.2` review continues to move forward item-by-item, with `Chapter1/01_06a_Discussion` now verified rather than merely scaffolded.
+- The discussion blob now has complete declaration-level coverage for its reviewed claim set: the real absolute value on `ℚ`, the existence of infinitely many other absolute values, and the unique signed prime-factorization of nonzero rationals.
+
+## Next step
+- Publish the PR for `#125` and then pick up the next unclaimed executable review or feature issue once the queue advances.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -408,10 +408,10 @@
     "notes": "Stage 3.2 review for issue #118 confirmed that SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean covers the blob's equivalence claim with explicit Lean bridges in both orientations: `isEquiv_iff_exists_rpow_eq_pointwise` records the pointwise power equation from `AbsoluteValue.isEquiv_iff_exists_rpow_eq`, and `isEquiv_iff_exists_rpow_eq_textbook` matches the lecture's exact `|x|' = |x|^α` wording. No definition-level sorries or coverage gaps remain."
   },
   "Chapter1/01_06a_Discussion": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-21",
-    "issue": "#120",
-    "notes": "Stage 3.1 scaffolding for issue #120 added SutherlandNumberTheoryLecture1/Chapter1/01_06a_Discussion.lean. The file packages the archimedean place on Q as `ratArchimedeanAbsoluteValue := Rat.AbsoluteValue.real`, proves its evaluation agrees with the usual absolute value, and states the archimedean/non-nonarchimedean and unique signed prime-factorization claims as theorem-level obligations. Later discussion about infinitely many other places and completions remains intentionally deferred.",
+    "issue": "#125",
+    "notes": "Stage 3.2 review for issue #125 closed the only coverage gap in SutherlandNumberTheoryLecture1/Chapter1/01_06a_Discussion.lean by adding `infinitelyMany_ratAbsoluteValues_not_isEquiv_archimedean` for the blob's sentence that Q has infinitely many absolute values besides `|.|_∞`. The file now covers all three blob-level claims with explicit declarations: `ratArchimedeanAbsoluteValue` and `ratArchimedeanAbsoluteValue_apply` bridge the real place to the lecture's `|.|_∞` notation, `ratArchimedeanAbsoluteValue_not_isNonarchimedean` records archimedeanness in the valuation-language used by the chapter, `infinitelyMany_ratAbsoluteValues_not_isEquiv_archimedean` captures the existence of infinitely many other places, and `existsUnique_signed_primeFactorization` formalizes the unique signed prime-factorization claim. Completion/local-field remarks remain intentionally outside this blob's reviewed claim set, and no definition-level sorries remain.",
     "stage3_1_decision": {
       "decision": "formalizable",
       "claims": [


### PR DESCRIPTION
## Summary
- close the Stage 3.2 coverage gap in `Chapter1/01_06a_Discussion` by adding an explicit theorem-level declaration for the blob's sentence that `ℚ` has infinitely many absolute values besides `|\cdot|_\infty`
- advance `Chapter1/01_06a_Discussion` to `definition_verified` in `progress/status.json`
- record the session handoff in `progress/2026-04-21T04-01-23Z_ec660d82.md`

## Stage 3.2 Coverage Audit
- [x] Claim 1: "The usual absolute value on `\mathbf{Q}` inherited from `\mathbf{R}` is written `|\cdot|_\infty` and is archimedean."
  Mapped to `ratArchimedeanAbsoluteValue`, `ratArchimedeanAbsoluteValue_apply`, and `ratArchimedeanAbsoluteValue_not_isNonarchimedean` in `SutherlandNumberTheoryLecture1/Chapter1/01_06a_Discussion.lean`.
- [x] Claim 2: "There are infinitely many absolute values on `\mathbf{Q}` besides `|\cdot|_\infty`."
  Mapped to `infinitelyMany_ratAbsoluteValues_not_isEquiv_archimedean` in `SutherlandNumberTheoryLecture1/Chapter1/01_06a_Discussion.lean`.
- [x] Claim 3: "Every nonzero rational can be written uniquely as `\pm \prod_q q^{e_q}` with integer exponents and finite support."
  Mapped to `existsUnique_signed_primeFactorization` in `SutherlandNumberTheoryLecture1/Chapter1/01_06a_Discussion.lean`.
- [x] Coverage gaps: none remain after adding Claim 2's declaration.
- [x] Non-trivial equivalence check: the textbook's `|\cdot|_\infty` notation is bridged explicitly to Mathlib's `Rat.AbsoluteValue.real` by `ratArchimedeanAbsoluteValue` and `ratArchimedeanAbsoluteValue_apply`; no additional bridge is needed for the remaining two claims because they are stated directly in the local file.
- [x] Definition integrity: no definition-level `sorry` was introduced; only theorem proofs remain deferred.

## Verification
- `lake exe cache get`
- `lake build`
