### PR TITLE
Review scaffolding for Chapter1/01_10_Definition

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean
@@ -11,8 +11,9 @@ object as `AddValuation k (WithTop ℝ)`, so this file records the lecture's
 definition directly in terms of the bundled additive valuation API.
 
 The derived nonarchimedean absolute value `|x|ᵥ = c ^ v(x)` for `0 < c < 1`
-is kept as an explicit declaration rather than prose-only commentary. The proof
-details are left at theorem level for later stages.
+is recorded via its explicit underlying formula and a theorem-level existence
+claim, so the construction remains visible without introducing a sorry'd data
+definition.
 
 For the valuation ring and DVR clauses, the lecture's constructions match
 Mathlib's bundled objects:
@@ -57,24 +58,24 @@ attached to the bundled valuation. -/
 noncomputable abbrev valuationSubring (v : RealValuation k) : ValuationSubring k :=
   (asValuation v).valuationSubring
 
-/-- The lecture's construction `|x|ᵥ = c ^ v(x)` for `0 < c < 1`. -/
-noncomputable def derivedAbsoluteValue (v : RealValuation k) (c : ℝ) (hc0 : 0 < c) (hc1 : c < 1) :
-    AbsoluteValue k ℝ := by
-  classical
-  refine
-    { toFun := fun x => if hx : x = 0 then 0 else c ^ ((v x).untop ((v.ne_top_iff).2 hx))
-      map_mul' := by
-        intro x y
-        sorry
-      nonneg' := by
-        intro x
-        sorry
-      eq_zero' := by
-        intro x
-        sorry
-      add_le' := by
-        intro x y
-        sorry }
+/-- The lecture's formula `|x|ᵥ = c ^ v(x)` on nonzero elements, extended by `0` at the origin. -/
+noncomputable def derivedAbsoluteValueFn (v : RealValuation k) (c : ℝ) : k → ℝ :=
+  by
+    classical
+    exact fun x => if hx : x = 0 then 0 else c ^ ((v x).untop ((v.ne_top_iff).2 hx))
+
+/-- The lecture's set-level description of the valuation ring agrees with Mathlib's bundled one. -/
+theorem mem_valuationSubring_iff (v : RealValuation k) (x : k) :
+    x ∈ valuationSubring v ↔ 0 ≤ v x := by
+  change (asValuation v) x ≤ 1 ↔ 0 ≤ v x
+  change OrderDual.toDual (v x) ≤ OrderDual.toDual (0 : WithTop ℝ) ↔ 0 ≤ v x
+  rfl
+
+/-- The lecture's formula `|x|ᵥ = c ^ v(x)` yields a nonarchimedean absolute value. -/
+theorem exists_derivedAbsoluteValue (v : RealValuation k) (c : ℝ) (hc0 : 0 < c) (hc1 : c < 1) :
+    ∃ abv : AbsoluteValue k ℝ, IsNonarchimedean abv ∧
+      ∀ x, abv x = derivedAbsoluteValueFn v c x := by
+  sorry
 
 /-- A valuation ring coming from a cyclic nontrivial value group is a DVR in Mathlib's sense. -/
 instance instIsDiscreteValuationRing (v : RealValuation k)

--- a/progress/2026-04-21T04-11-48Z_7f8d5b75.md
+++ b/progress/2026-04-21T04-11-48Z_7f8d5b75.md
@@ -1,0 +1,19 @@
+## Accomplished
+- Claimed review issue `#143` for `Chapter1/01_10_Definition` and ran the required Stage `3.2` coverage audit against `blobs/Chapter1/01_10_Definition.md` and `SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean`.
+- Repaired the review blocker in the scaffold: replaced the illegal sorry'd data definition `derivedAbsoluteValue` with the real formula `derivedAbsoluteValueFn` plus the theorem-level scaffold `exists_derivedAbsoluteValue`.
+- Added `mem_valuationSubring_iff` so the lecture's set-level description `A = {x : v(x) >= 0}` is bridged explicitly to Mathlib's bundled valuation subring.
+- Advanced `Chapter1/01_10_Definition` to `definition_verified` in `progress/status.json`.
+- Ran `lake exe cache get` and `lake build`; the build completed successfully.
+
+## Current frontier
+- Issue `#143` is ready to publish as a Stage `3.2` review PR with the explicit coverage-audit checklist in the PR body.
+
+## Overall project progress
+- Chapter 1 valuation/DVR scaffolding now has its entry-point definition reviewed and definition-level-safe.
+- `Chapter1/01_10_Definition` no longer contains a sorry'd data declaration, so downstream valuation vocabulary can build on a valid Stage `3.2` base.
+
+## Next step
+- Publish the review PR for `#143`, then move to `Chapter1/01_11_Definition` as the next valuation vocabulary scaffold unless a higher-priority repair/review issue appears first.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -498,10 +498,10 @@
     }
   },
   "Chapter1/01_10_Definition": {
-    "status": "scaffolded",
-    "last_updated": "2026-04-20",
-    "issue": "#134",
-    "notes": "Stage 3.1 scaffolded `SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean` by identifying the lecture's valuation with `AddValuation k (WithTop ℝ)`, recording the normalized discrete-value-group predicate on units, exposing `derivedAbsoluteValue`, and reusing `valuationSubring` plus `IsDiscreteValuationRing` for the valuation-ring/DVR clauses."
+    "status": "definition_verified",
+    "last_updated": "2026-04-21",
+    "issue": "#143",
+    "notes": "Stage 3.2 reviewed `SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean`, replaced the illegal sorry'd `derivedAbsoluteValue` data definition with the real formula `derivedAbsoluteValueFn` plus a theorem-level existence scaffold, and added `mem_valuationSubring_iff` so the lecture's set-level valuation-ring description is bridged explicitly to Mathlib's bundled `valuationSubring`."
   },
   "Chapter1/01_10a_Discussion": {
     "status": "needs_definition",


### PR DESCRIPTION
## Summary
- fix the Stage 3.2 blocker in `Chapter1/01_10_Definition` by replacing the sorry'd `derivedAbsoluteValue` data definition with the real formula `derivedAbsoluteValueFn` plus theorem-level existence scaffolding
- add `mem_valuationSubring_iff` so the lecture's set-level valuation-ring description is bridged explicitly to Mathlib's bundled `valuationSubring`
- advance `Chapter1/01_10_Definition` to `definition_verified` and record the handoff in `progress/2026-04-21T04-11-48Z_7f8d5b75.md`

## Verification
- `lake exe cache get`
- `lake build`

## Stage 3.2 Coverage Audit
- [x] Claim 1: A valuation on a field `k` is a homomorphism `k^\times -> \mathbf{R}` satisfying `v(x + y) \ge \min(v(x), v(y))`.
  Mapped to `RealValuation`, which identifies the lecture's notion with `AddValuation k (WithTop ℝ)`.
- [x] Claim 2: The valuation extends to a map `k -> \mathbf{R} \cup \{\infty\}` by setting `v(0) := \infty`.
  Covered by the bundled `AddValuation` API; no local bridge is needed because the codomain is definitionally `WithTop ℝ`, and `AddValuation.map_zero` gives the stated value at `0`.
- [x] Claim 3: For `0 < c < 1`, the formula `|x|_v := c^{v(x)}` yields a nonarchimedean absolute value.
  Mapped to `derivedAbsoluteValueFn` for the explicit formula and `exists_derivedAbsoluteValue` for the theorem-level existence/nonarchimedean claim.
- [x] Claim 4: The image of `v` in `\mathbf{R}` is the value group.
  Mapped to `valueGroup`.
- [x] Claim 5: A discrete valuation is one whose value group is `\mathbf{Z}` after the lecture's normalization.
  Mapped to `IsDiscrete`. The parenthetical rescaling justification is treated here as motivational normalization commentary rather than a separate downstream declaration requirement.
- [x] Claim 6: The set `A := {x \in k : v(x) \ge 0}` is the valuation ring of `k`.
  Mapped to `valuationSubring` together with the explicit bridge theorem `mem_valuationSubring_iff`.
- [x] Claim 7: A DVR is an integral domain that is the valuation ring of its fraction field with respect to a discrete valuation.
  Mapped to `instIsDiscreteValuationRing`, which reuses Mathlib's bundled `IsDiscreteValuationRing` instance on the valuation subring.
- [x] Claim 8: Such a ring cannot be a field.
  Mapped to `valuationSubring_maximalIdeal_ne_bot`.

## Review Notes
- The review initially failed because `derivedAbsoluteValue` was a `def` whose structure fields were all `sorry`; this PR repairs that definition-level violation directly.
- No definition-level `sorry` bodies remain in `SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean` after the review fix.
