### PR TITLE
Review Chapter1/01_19_Definition scaffolding

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_19_Definition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_19_Definition.lean
@@ -21,6 +21,11 @@ section Definition_01_19
 
 variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
 
+/-- Definition 1.19's ambient-extension construction is the bundled integral closure. -/
+theorem integralClosure_isIntegralClosure :
+    IsIntegralClosure (integralClosure A B) A B :=
+  integralClosure.isIntegralClosure A B
+
 /-- Definition 1.19's ambient-extension object is Mathlib's `integralClosure A B`. -/
 theorem mem_integralClosure_iff_isIntegral {b : B} :
     b ∈ integralClosure A B ↔ IsIntegral A b := by
@@ -37,6 +42,11 @@ end Definition_01_19
 section Definition_01_19_FractionField
 
 variable (A : Type*) [CommRing A]
+
+/-- For a domain, the lecture's normalization is the integral closure in its fraction field. -/
+theorem normalization_isIntegralClosure [IsDomain A] :
+    IsIntegralClosure (integralClosure A (FractionRing A)) A (FractionRing A) :=
+  integralClosure.isIntegralClosure A (FractionRing A)
 
 /-- For a domain, the lecture's normalization is the integral closure in its fraction field. -/
 theorem mem_normalization_iff_isIntegral [IsDomain A] {x : FractionRing A} :

--- a/progress/2026-04-21T04-21-29Z.md
+++ b/progress/2026-04-21T04-21-29Z.md
@@ -1,0 +1,19 @@
+## Accomplished
+- Claimed review issue `#128` for `Chapter1/01_19_Definition` and completed the Stage `3.2` scaffolding review against the blob, refs note, and Lean scaffold.
+- Strengthened `SutherlandNumberTheoryLecture1/Chapter1/01_19_Definition.lean` with explicit declarations exposing the ambient integral-closure object and the fraction-field normalization object via `integralClosure.isIntegralClosure`.
+- Verified that the lecture's `\widetilde A = A` wording is bridged explicitly to Mathlib's bundled formulation `integralClosure A B = ⊥ ↔ IsIntegrallyClosedIn A B`, and that the domain-level specialization uses `IsIntegrallyClosed A`.
+- Updated `progress/status.json` so `Chapter1/01_19_Definition` is now `definition_verified`.
+- Ran `lake exe cache get`, rebuilt the target module, and ran a full `lake build` successfully.
+
+## Current frontier
+- Issue `#128` is ready to publish as a Stage `3.2` review PR with the coverage-audit checklist in the PR body.
+
+## Overall project progress
+- The Chapter 1 integrality vocabulary now has `Chapter1/01_19_Definition` reviewed and marked `definition_verified`, so downstream exact-match integrally-closed items can proceed on a reviewed base.
+- The repository still contains proof-level `sorry` warnings in earlier files, but there are no new definition-level integrity problems introduced by this review.
+
+## Next step
+- Publish the review PR for `#128`, then move to the next highest-priority unblocked item in the integrality chain, currently `Chapter1/01_22_Proposition` unless a PR-fix issue takes precedence.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -683,10 +683,10 @@
     "notes": "Stage 2.6 attached blobs/Chapter1/01_18_Proof.refs.md, recording the exact closure lemmas already in Mathlib and the Stacks section as the best prose replacement for the textbook's symmetric-polynomial proof."
   },
   "Chapter1/01_19_Definition": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-21",
-    "issue": "#116",
-    "notes": "Stage 3.1 scaffolded `SutherlandNumberTheoryLecture1/Chapter1/01_19_Definition.lean` with explicit declarations for membership in `integralClosure A B`, the bundled `IsIntegrallyClosedIn A B` property via `integralClosure A B = ⊥`, and the fraction-field specialization using `IsIntegrallyClosed A`."
+    "issue": "#128",
+    "notes": "Stage 3.2 review verified `SutherlandNumberTheoryLecture1/Chapter1/01_19_Definition.lean`: the file now exposes the ambient and fraction-field integral-closure objects via `integralClosure.isIntegralClosure`, bridges the lecture's `\\widetilde A = A` wording to `integralClosure A B = ⊥`/`IsIntegrallyClosedIn A B`, and states the fraction-field specialization with `IsIntegrallyClosed A`."
   },
   "Chapter1/01_20_Proposition": {
     "status": "references_attached",


### PR DESCRIPTION
## Summary
- complete the Stage 3.2 review for `Chapter1/01_19_Definition`
- expose the ambient and fraction-field integral-closure objects explicitly via `integralClosure.isIntegralClosure`
- advance `Chapter1/01_19_Definition` to `definition_verified` in `progress/status.json`

## Coverage Audit
- [x] Claim: Given a ring extension `B/A`, `\widetilde A = {b \in B : b \text{ is integral over } A}` is the integral closure of `A` in `B`.
  Lean mapping: `integralClosure_isIntegralClosure` and `mem_integralClosure_iff_isIntegral` in `SutherlandNumberTheoryLecture1/Chapter1/01_19_Definition.lean`.
- [x] Claim: When `\widetilde A = A`, the ring `A` is integrally closed in `B`.
  Lean mapping: `integralClosure_eq_bot_iff_isIntegrallyClosedIn`, which bridges the lecture's unbundled equality to Mathlib's bundled `integralClosure A B = ⊥` formulation.
- [x] Claim: For a domain `A`, its integral closure / normalization is its integral closure in its fraction field.
  Lean mapping: `normalization_isIntegralClosure` and `mem_normalization_iff_isIntegral`.
- [x] Claim: For a domain `A`, `A` is integrally closed / normal iff it is integrally closed in its fraction field.
  Lean mapping: `isIntegrallyClosed_iff_isIntegrallyClosedIn_fractionRing`.
- [x] Non-trivial equivalences checked.
  Review note: the lecture's `\widetilde A = A` wording is not definitionally equal to Mathlib's bundled subalgebra presentation, so the file includes the explicit bridge theorem `integralClosure_eq_bot_iff_isIntegrallyClosedIn`.
- [x] Definition integrity checked.
  Review note: no definition-level `sorry` bodies appear in `SutherlandNumberTheoryLecture1/Chapter1/01_19_Definition.lean`.

## Verification
- `lake build SutherlandNumberTheoryLecture1.Chapter1.«01_19_Definition»`
- `lake build`
