### PR TITLE
Review scaffolding for Chapter1/01_11_Definition

### DIFF
--- a/progress/2026-04-21T04-26-58Z_154ccf2e.md
+++ b/progress/2026-04-21T04-26-58Z_154ccf2e.md
@@ -1,0 +1,22 @@
+## Accomplished
+- Claimed review issue `#144` for `Chapter1/01_11_Definition`.
+- Performed the Stage `3.2` coverage audit against `blobs/Chapter1/01_11_Definition.md` and `SutherlandNumberTheoryLecture1/Chapter1/01_11_Definition.lean`.
+- Verified the blob has one mathematical claim: the valuation-ring definition for an integral domain in its fraction field.
+- Verified coverage is complete: `valuationRing_iff_forall_isInteger_or_isInteger_inv` matches Mathlib's predicate, and `valuationRing_iff_forall_exists_eq_algebraMap_or_inv_eq_algebraMap` provides the explicit textbook `x ∈ A` / `x⁻¹ ∈ A` bridge.
+- Confirmed there are no definition-level `sorry`s in `01_11_Definition.lean`.
+- Updated `progress/status.json` to mark `Chapter1/01_11_Definition` as `definition_verified`.
+- Ran `lake build` successfully.
+
+## Current frontier
+- Issue `#144` is ready to publish as a Stage `3.2` review PR with the coverage audit in the PR body.
+
+## Overall project progress
+- Chapter 1 Stage `3.1`/`3.2` work continues to move through the valuation and integrality queues.
+- `Chapter1/01_11_Definition` has now advanced from `scaffolded` to `definition_verified`, so the first valuation-ring definition is cleared for later Stage `3.3` audit work.
+
+## Next step
+- Publish the review PR for `#144`.
+- After it lands, proceed to `#137` (`Chapter1/01_12_Definition`), which is now the next valuation/DVR vocabulary scaffold.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -557,10 +557,10 @@
     }
   },
   "Chapter1/01_11_Definition": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-21",
-    "issue": "#136",
-    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_11_Definition.lean as a direct wrapper around `ValuationRing`, with explicit fraction-field statements `valuationRing_iff_forall_isInteger_or_isInteger_inv` and `valuationRing_iff_forall_exists_eq_algebraMap_or_inv_eq_algebraMap` matching the lecture's membership phrasing."
+    "issue": "#144",
+    "notes": "Stage 3.2 review verified that blobs/Chapter1/01_11_Definition.md has one mathematical claim, fully covered by `valuationRing_iff_forall_isInteger_or_isInteger_inv` together with the explicit textbook-phrasing bridge `valuationRing_iff_forall_exists_eq_algebraMap_or_inv_eq_algebraMap`; no coverage gaps or definition-level sorries were found."
   },
   "Chapter1/01_11a_Discussion": {
     "status": "references_attached",


### PR DESCRIPTION
## Summary
- advance `Chapter1/01_11_Definition` from `scaffolded` to `definition_verified`
- record the Stage 3.2 coverage audit in `progress/status.json`
- add the required handoff entry in `progress/2026-04-21T04-26-58Z_154ccf2e.md`

## Verification
- `lake build`

## Stage 3.2 Coverage Audit
- [x] Enumerate claims
  `blobs/Chapter1/01_11_Definition.md` has one mathematical claim: Definition 1.11 says that a valuation ring is an integral domain `A` with fraction field `k` such that for every `x : k`, either `x ∈ A` or `x⁻¹ ∈ A`.
- [x] Map to Lean
  This is covered by `valuationRing_iff_forall_isInteger_or_isInteger_inv`, which exposes Mathlib's exact `ValuationRing` predicate with the fraction-field ambient data explicit in the theorem parameters, together with `valuationRing_iff_forall_exists_eq_algebraMap_or_inv_eq_algebraMap`, which bridges to the textbook membership phrasing `x = algebraMap A k a` or `x⁻¹ = algebraMap A k a`.
- [x] Flag gaps
  No coverage gaps were found.
- [x] Check non-trivial equivalences
  The textbook `x ∈ A` / `x⁻¹ ∈ A` wording is not definitionally identical to `IsLocalization.IsInteger`; the explicit bridge theorem `valuationRing_iff_forall_exists_eq_algebraMap_or_inv_eq_algebraMap` supplies the required equivalence.
- [x] Check definition integrity
  `SutherlandNumberTheoryLecture1/Chapter1/01_11_Definition.lean` contains no definition-level `sorry`s and no sorried data declarations.

Closes #144
