### PR TITLE
Repair PR #219 Chapter1/01_21_Corollary conflicts

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1.lean
@@ -27,6 +27,7 @@ import SutherlandNumberTheoryLecture1.Chapter1.«01_18_Proposition»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_19_Definition»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_20_Proposition»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_20_Proof»
+import SutherlandNumberTheoryLecture1.Chapter1.«01_21_Corollary»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_22_Proposition»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_23_Corollary»
 import SutherlandNumberTheoryLecture1.Chapter1.«01_28_Proposition»

--- a/SutherlandNumberTheoryLecture1/Chapter1/01_21_Corollary.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_21_Corollary.lean
@@ -1,0 +1,31 @@
+import Mathlib
+import SutherlandNumberTheoryLecture1.Chapter1.«01_19_Definition»
+import SutherlandNumberTheoryLecture1.Chapter1.«01_20_Proposition»
+
+/-!
+# Corollary 1.21: The integral closure is integrally closed
+
+For a ring extension `B / A`, the lecture observes that the integral closure of
+`A` in `B` is itself integrally closed in `B`. Mathlib already packages the
+integral closure as `integralClosure A B` and proves the corresponding ambient
+integrally-closed statement via `IsIntegrallyClosedIn.of_isIntegralClosure`.
+-/
+
+namespace SutherlandNumberTheoryLecture1
+namespace Chapter1
+
+section Corollary_01_21
+
+variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
+
+/-- Corollary 1.21: the integral closure of `A` in `B` is integrally closed in `B`. -/
+theorem integralClosure_isIntegrallyClosedIn :
+    IsIntegrallyClosedIn (integralClosure A B) B := by
+  simpa using
+    (IsIntegrallyClosedIn.of_isIntegralClosure
+      (R := A) (A := integralClosure A B) (B := B))
+
+end Corollary_01_21
+
+end Chapter1
+end SutherlandNumberTheoryLecture1

--- a/progress/2026-04-21T04-59-42Z_233ac924.md
+++ b/progress/2026-04-21T04-59-42Z_233ac924.md
@@ -1,0 +1,18 @@
+## Accomplished
+- Claimed repair issue `#224` for conflicted PR `#219` (`Chapter1/01_21_Corollary`).
+- Replayed the intended Stage 3.1 scaffold onto current `master` by adding `SutherlandNumberTheoryLecture1/Chapter1/01_21_Corollary.lean`, restoring the Chapter 1 import spine entry, and advancing `Chapter1/01_21_Corollary` to `scaffolded` in `progress/status.json`.
+- Ran `lake exe cache get` and `lake build`; the build succeeded on current `master`. Existing warnings come from earlier theorem-level `sorry` placeholders and unrelated linter noise.
+
+## Current frontier
+- The `Chapter1/01_21_Corollary` repair is ready to publish as a replacement for PR `#219`.
+
+## Overall project progress
+- Chapter 1 Stage 3.1 scaffolding remains active through the integrality/localization block.
+- `Chapter1/01_21_Corollary` is now restacked cleanly on current `master`, which restores the missing scaffold needed before the follow-on proof item can proceed.
+
+## Next step
+- Publish the replacement PR for this repair issue and note that it supersedes `#219`.
+- Once the replacement lands, claim `#145` (`Chapter1/01_21_Proof`), which becomes executable again after `#140` is effectively restored on `master`.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -701,10 +701,10 @@
     "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_20_Proof.lean by formalizing the proof blob as the elementwise tower-transitivity step `isIntegral_of_isIntegral_tower`, citing Mathlib's `isIntegral_trans` and re-exporting Proposition 1.20 through `integral_extension_trans_from_proof`."
   },
   "Chapter1/01_21_Corollary": {
-    "status": "references_attached",
-    "last_updated": "2026-04-20",
-    "issue": "#90",
-    "notes": "Stage 2.6 attached blobs/Chapter1/01_21_Corollary.refs.md, mapping the corollary directly onto `integralClosure` and `IsIntegrallyClosedIn.of_isIntegralClosure`."
+    "status": "scaffolded",
+    "last_updated": "2026-04-21",
+    "issue": "#140",
+    "notes": "Stage 3.1 scaffolded SutherlandNumberTheoryLecture1/Chapter1/01_21_Corollary.lean by formalizing Corollary 1.21 as the bundled statement that `integralClosure A B` is integrally closed in `B`, proved via `IsIntegrallyClosedIn.of_isIntegralClosure`."
   },
   "Chapter1/01_21_Proof": {
     "status": "references_attached",


### PR DESCRIPTION
Closes #224
Closes #140

Supersedes #219 by replaying the intended `Chapter1/01_21_Corollary` Stage 3.1 scaffold onto current `master`.

This restores:
- `SutherlandNumberTheoryLecture1/Chapter1/01_21_Corollary.lean`
- the Chapter 1 import spine entry
- the matching `progress/status.json` transition to `scaffolded`

Verification:
- `lake exe cache get`
- `lake build`

Once this lands, `#145` (`Chapter1/01_21_Proof`) is executable again.