### PR TITLE
Review Chapter1/01_13_Definition scaffolding

### DIFF
--- a/progress/2026-04-21T05-03-24Z.md
+++ b/progress/2026-04-21T05-03-24Z.md
@@ -1,0 +1,17 @@
+## Accomplished
+- Reviewed `Chapter1/01_13_Definition` against the blob and Stage 3.2 checklist.
+- Confirmed the blob has a single mathematical claim and that `SutherlandNumberTheoryLecture1/Chapter1/01_13_Definition.lean` covers it with explicit bridges to `IsLocalRing.ResidueField` and `IsLocalRing.residue`.
+- Advanced `progress/status.json` for `Chapter1/01_13_Definition` from `scaffolded` to `definition_verified`.
+
+## Current frontier
+- The review is ready to publish once Lean verification passes and the PR body records the explicit coverage audit for issue `#142`.
+
+## Overall project progress
+- Chapter 1 Stage 3.2 review continues to move the early local-ring vocabulary from `scaffolded` to `definition_verified`.
+- `Chapter1/01_13_Definition` is now ready for downstream Stage 3.3 auditing after the review PR is published.
+
+## Next step
+- Publish the review PR for issue `#142`, then continue with the next available Chapter 1 review or scaffolding-repair issue once unblocked.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -575,10 +575,10 @@
     "notes": "Stage 3.2 review for issue #141 confirmed that blobs/Chapter1/01_12_Definition.md has one mathematical claim, fully covered by `localRing_iff_existsUnique_maximalIdeal` together with `maximalIdeal_isMaximal`. The scaffold uses `IsLocalRing` and `IsLocalRing.maximalIdeal` directly, keeps the unique-maximal-ideal criterion explicit in Lean, and contains no definition-level `sorry`."
   },
   "Chapter1/01_13_Definition": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-21",
-    "issue": "#138",
-    "notes": "Stage 3.1 scaffolded `SutherlandNumberTheoryLecture1/Chapter1/01_13_Definition.lean` directly against `IsLocalRing.ResidueField`; the file states the lecture's residue-field definition as the quotient `A ⧸ IsLocalRing.maximalIdeal A` and exposes the canonical quotient map through `residue_eq_idealQuotient_mk`."
+    "issue": "#142",
+    "notes": "Stage 3.2 review for issue #142 confirmed that blobs/Chapter1/01_13_Definition.md has one mathematical claim, fully covered by `residueField_eq_quotient`. The scaffold uses `IsLocalRing.ResidueField` and `IsLocalRing.residue` directly, makes the quotient field and canonical quotient map explicit via `residueField_eq_quotient` and `residue_eq_idealQuotient_mk`, introduces no project-local duplicate construction, and contains no definition-level `sorry`."
   },
   "Chapter1/01_13a_Discussion": {
     "status": "references_attached",


### PR DESCRIPTION
Fixes #142

## Stage 3.2 Coverage Audit

1. Enumerate claims
- Claim: Definition 1.13 introduces the residue field of a local ring $A$ with maximal ideal $\mathfrak{m}$ as the field $A/\mathfrak{m}$.

2. Map to Lean
- `SutherlandNumberTheoryLecture1.Chapter1.residueField_eq_quotient` formalizes the definition by identifying `IsLocalRing.ResidueField A` with `(A ⧸ IsLocalRing.maximalIdeal A)`.
- `SutherlandNumberTheoryLecture1.Chapter1.residue_eq_idealQuotient_mk` makes the canonical quotient map explicit as `Ideal.Quotient.mk (IsLocalRing.maximalIdeal A)`, matching the blob's quotient-map content expected by the Stage 3.2 review checklist.

3. Flag gaps
- No coverage gaps. The blob has one mathematical claim, and the scaffold contains explicit Lean declarations for both the quotient field object and quotient map.

4. Check non-trivial equivalences
- No extra bridge beyond the two explicit `rfl` theorems is needed: Mathlib's `IsLocalRing.ResidueField` is definitionally the quotient by `IsLocalRing.maximalIdeal`, and `IsLocalRing.residue` is definitionally `Ideal.Quotient.mk` for that ideal.

5. Check definition integrity
- No definition-level `sorry` appears in `SutherlandNumberTheoryLecture1/Chapter1/01_13_Definition.lean`.

## Verification
- Ran `lake exe cache get`
- Ran `lake build` successfully; remaining warnings are pre-existing `sorry`/linter warnings in other files.