### PR TITLE
Review scaffold coverage for Chapter1/01_13a_Discussion

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_13a_Discussion.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_13a_Discussion.lean
@@ -89,6 +89,12 @@ theorem isEquiv_dvrValuation_of_valuationSubring_eq {Γ : Type*}
   rw [Valuation.isEquiv_iff_valuationSubring]
   simpa [dvrValuationSubring] using hA
 
+/-- The recovered valuation admits a uniformizer in its valuation subring. -/
+theorem exists_uniformizer_dvrValuation :
+    ∃ π : dvrValuationSubring A K, (dvrValuation A K).IsUniformizer (π : K) := by
+  simpa [dvrValuationSubring] using
+    (Valuation.exists_isUniformizer_of_isCyclic_of_nontrivial (v := dvrValuation A K))
+
 /-- For the recovered valuation, generators of the maximal ideal are exactly uniformizers. -/
 theorem maximalIdeal_eq_span_iff_isUniformizer (π : dvrValuationSubring A K) :
     IsLocalRing.maximalIdeal (dvrValuationSubring A K) = Ideal.span {π} ↔

--- a/progress/2026-04-21T07-43-43Z_3a196e0c.md
+++ b/progress/2026-04-21T07-43-43Z_3a196e0c.md
@@ -1,0 +1,20 @@
+## Accomplished
+- Claimed review issue `#292` for `Chapter1/01_13a_Discussion` and completed the Stage 3.2 scaffolding review against the blob, refs note, and Lean scaffold.
+- Verified that the powers-of-the-maximal-ideal valuation construction, fraction-field extension, valuation-ring recovery, and uniqueness claims are all represented in `SutherlandNumberTheoryLecture1/Chapter1/01_13a_Discussion.lean`.
+- Added `exists_uniformizer_dvrValuation` so the blob's explicit existence claim for a recovered uniformizer is stated locally rather than only implicit in imported Mathlib API.
+- Updated `progress/status.json` to move `Chapter1/01_13a_Discussion` from `scaffolded` to `definition_verified` and recorded the full Stage 3.2 claim-by-claim audit.
+- Ran `lake exe cache get` and `lake build`; the build succeeded after renaming the new theorem to avoid a namespace collision with `01_11a_Discussion`.
+
+## Current frontier
+- `Chapter1/01_13a_Discussion` is ready for the separate Stage 3.3 missing-claims audit.
+- The remaining visible unclaimed review work is `#292`'s sibling audit path for nearby Chapter 1 discussion blobs once new issues are created.
+
+## Overall project progress
+- Chapter 1's valuation/DVR discussion sequence now has Stage 3.2 review completed for `01_13a` and `01_15a`, with `01_13a` promoted to `definition_verified`.
+- The repository still has pre-existing theorem-level `sorry` warnings elsewhere in Chapter 1, but this turn introduced no definition-level `sorry` and no new build failures.
+
+## Next step
+- Open the review PR for issue `#292` with the Stage 3.2 coverage checklist in the PR body, then hand the blob off for Stage 3.3 missing-claims auditing.
+
+## Blockers
+- None.

--- a/progress/status.json
+++ b/progress/status.json
@@ -780,10 +780,59 @@
     "notes": "Stage 3.2 review for issue #142 confirmed that blobs/Chapter1/01_13_Definition.md has one mathematical claim, fully covered by `residueField_eq_quotient`. The scaffold uses `IsLocalRing.ResidueField` and `IsLocalRing.residue` directly, makes the quotient field and canonical quotient map explicit via `residueField_eq_quotient` and `residue_eq_idealQuotient_mk`, introduces no project-local duplicate construction, and contains no definition-level `sorry`."
   },
   "Chapter1/01_13a_Discussion": {
-    "status": "scaffolded",
+    "status": "definition_verified",
     "last_updated": "2026-04-21",
-    "issue": "#271",
-    "notes": "Stage 3.1 scaffolded `SutherlandNumberTheoryLecture1/Chapter1/01_13a_Discussion.lean` around Mathlib's DVR/valuation correspondence. The new file defines the maximal-ideal adic valuation on the DVR and its extension to the fraction field, records the `v(x) ≤ 1` characterization of the recovered valuation ring, packages the recovery of `A` inside the fraction field via `equivValuationSubring` and `map_algebraMap_eq_valuationSubring`, and states the uniqueness and uniformizer-generator equivalence claims explicitly without introducing any definition-level `sorry`."
+    "issue": "#292",
+    "notes": "Stage 3.2 review for issue #292 confirmed that `blobs/Chapter1/01_13a_Discussion.md` is fully covered by `SutherlandNumberTheoryLecture1/Chapter1/01_13a_Discussion.lean`. The file packages the maximal-ideal adic valuation on the DVR and its extension to the fraction field, records the `v(x) ≤ 1` characterization of the recovered valuation ring and the reconstruction of `A` via `equivValuationSubring` and `map_algebraMap_eq_valuationSubring`, and now makes the recovered valuation's uniformizer existence explicit before the uniqueness and uniformizer-generator equivalence claims. No definition-level `sorry` was found.",
+    "stage3_2_review": {
+      "issue": "#292",
+      "decision": "passes_with_bridge_added",
+      "claims": [
+        {
+          "n": 1,
+          "text": "For a DVR `A` with maximal ideal `m`, the valuation on `A` is defined by the powers of `m` via `(a) = m^n`, with `v(0) = infinity`.",
+          "classification": "formalized_here",
+          "location": "SutherlandNumberTheoryLecture1.Chapter1.maximalIdealIntValuation; SutherlandNumberTheoryLecture1.Chapter1.maximalIdealIntValuation_le_pow_iff_mem",
+          "reason": "The file exposes the adic valuation attached to the distinguished maximal ideal and states the lecture's powers-of-the-maximal-ideal membership characterization explicitly."
+        },
+        {
+          "n": 2,
+          "text": "Extending that valuation to the fraction field by `v(a/b) = v(a) - v(b)` gives a discrete valuation on `Frac(A)`.",
+          "classification": "formalized_here",
+          "location": "SutherlandNumberTheoryLecture1.Chapter1.dvrValuation",
+          "reason": "Mathlib's DVR adic-valuation API already provides the induced fraction-field valuation, and the scaffold names that construction directly."
+        },
+        {
+          "n": 3,
+          "text": "The recovered valuation ring is exactly `A = {x in k : v(x) >= 0}`.",
+          "classification": "formalized_here",
+          "location": "SutherlandNumberTheoryLecture1.Chapter1.mem_dvrValuationSubring_iff; SutherlandNumberTheoryLecture1.Chapter1.dvrValuationSubring_eq_setOf_nonnegative; SutherlandNumberTheoryLecture1.Chapter1.dvrValuationSubring_toSubring_eq_image; SutherlandNumberTheoryLecture1.Chapter1.dvrValuation_integer_eq_image; SutherlandNumberTheoryLecture1.Chapter1.equivDvrValuationSubring",
+          "reason": "The file records both the set-theoretic cutoff condition and the canonical identification of the resulting valuation subring with the original DVR inside its fraction field."
+        },
+        {
+          "n": 4,
+          "text": "Any discrete valuation on `k` with valuation ring `A` must be the same recovered valuation.",
+          "classification": "formalized_here",
+          "location": "SutherlandNumberTheoryLecture1.Chapter1.isEquiv_dvrValuation_of_valuationSubring_eq",
+          "reason": "The lecture's uniqueness statement is represented by equivalence of valuations determined by equality of valuation subrings."
+        },
+        {
+          "n": 5,
+          "text": "There exists `pi` with valuation `1`, and `v(pi) = 1` exactly when `pi` generates the maximal ideal.",
+          "classification": "formalized_here",
+          "location": "SutherlandNumberTheoryLecture1.Chapter1.exists_uniformizer_dvrValuation; SutherlandNumberTheoryLecture1.Chapter1.maximalIdeal_eq_span_iff_isUniformizer",
+          "reason": "The review added the missing explicit existence bridge for a uniformizer of the recovered valuation and confirmed the generator/uniformizer equivalence already present."
+        },
+        {
+          "n": 6,
+          "text": "A uniformizer could equivalently be defined as any generator of the maximal ideal, without referencing the valuation.",
+          "classification": "formalized_here",
+          "location": "SutherlandNumberTheoryLecture1.Chapter1.maximalIdeal_eq_span_iff_isUniformizer",
+          "reason": "The iff theorem directly identifies the lecture's two formulations."
+        }
+      ],
+      "summary": "The Stage 3.2 review found one missing explicit bridge, namely existence of a uniformizer for the recovered valuation. After adding `exists_uniformizer_dvrValuation`, every mathematical sentence in the blob is represented by a declaration or direct Mathlib dependency, and the file remains free of definition-level `sorry`."
+    }
   },
   "Chapter1/01_14_Example": {
     "status": "scaffolded",


### PR DESCRIPTION
## Summary
Completed the Stage 3.2 scaffolding review for `Chapter1/01_13a_Discussion`.

## Stage 3.2 Coverage Audit
- [x] Claim 1: the DVR's valuation on `A` via powers of the maximal ideal is represented by `maximalIdealIntValuation` and `maximalIdealIntValuation_le_pow_iff_mem`.
- [x] Claim 2: the induced fraction-field valuation is represented by `dvrValuation`.
- [x] Claim 3: the recovered valuation ring `A = {x : K | v x >= 0}` is represented by `mem_dvrValuationSubring_iff`, `dvrValuationSubring_eq_setOf_nonnegative`, `dvrValuationSubring_toSubring_eq_image`, `dvrValuation_integer_eq_image`, and `equivDvrValuationSubring`.
- [x] Claim 4: uniqueness of the recovered valuation is represented by `isEquiv_dvrValuation_of_valuationSubring_eq`.
- [x] Claim 5: existence of `pi` with valuation `1` is now stated explicitly by `exists_uniformizer_dvrValuation`.
- [x] Claim 6: `v(pi) = 1` iff `pi` generates the maximal ideal is represented by `maximalIdeal_eq_span_iff_isUniformizer`.
- [x] No definition-level `sorry` was introduced or found in `SutherlandNumberTheoryLecture1/Chapter1/01_13a_Discussion.lean`.

## Verification
- `lake exe cache get`
- `lake build`
