### PR TITLE
Refactor Chapter1/01_28_Proof to use direct Mathlib integrally-closed APIs

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_28_Proof.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_28_Proof.lean
@@ -6,9 +6,8 @@ import SutherlandNumberTheoryLecture1.Chapter1.«01_28_Proposition»
 The lecture proves the forward implication by factoring the minimal polynomial
 over an algebraic closure and then observing that its coefficients are integral
 over the base ring. Mathlib already packages that argument in the
-integrally-closed `minpoly` API, so this file records the textbook proof as a
-small collection of explicit theorem-level wrappers around those lemmas, while
-keeping the proof blob's assumptions slightly lighter than the proposition file.
+integrally-closed `minpoly` API, so this file keeps only the proof-blob
+statement whose assumptions are genuinely lighter than the proposition file.
 -/
 
 namespace SutherlandNumberTheoryLecture1
@@ -22,29 +21,6 @@ variable {A K L : Type*}
 variable [CommRing A] [IsDomain A] [Field K] [Field L]
 variable [Algebra A K] [Algebra A L] [Algebra K L] [IsScalarTower A K L]
 variable [IsIntegrallyClosed A]
-
-/-- Any monic lift of the fraction-field minimal polynomial forces the base-ring
-minimal polynomial to divide it. This is the packaged replacement for the
-textbook's factor-by-factor argument in an algebraic closure. -/
-theorem minpoly_dvd_of_monic_lifted_root [Module.IsTorsionFree A L]
-    {α : L} {g : A[X]} (hg : g.Monic) (hroot : aeval α (g.map (algebraMap A K)) = 0) :
-    minpoly A α ∣ g := by
-  exact minpoly.isIntegrallyClosed_dvd ⟨g, hg, by
-    rw [Polynomial.aeval_map_algebraMap K α g] at hroot
-    exact hroot⟩ <| by
-      rw [Polynomial.aeval_map_algebraMap K α g] at hroot
-      exact hroot
-
-/-- If `α` is integral over `A`, then every coefficient of its minimal
-polynomial over the fraction field `K` already comes from `A`. This packages the
-lecture's final "integral closure intersect the fraction field" step. -/
-theorem minpoly_coeff_lifts_to_base [IsFractionRing A K] {α : L} (hα : IsIntegral A α) (n : ℕ) :
-    ∃ a : A, algebraMap A K a = (minpoly K α).coeff n := by
-  have hcoeff_integral : IsIntegral A ((minpoly K α).coeff n) := by
-    rw [minpoly.isIntegrallyClosed_eq_field_fractions' K hα, coeff_map]
-    simpa using
-      (isIntegral_algebraMap : IsIntegral A (algebraMap A K ((minpoly A α).coeff n)))
-  exact IsIntegrallyClosed.isIntegral_iff.mp hcoeff_integral
 
 /-- The proof blob for Proposition 1.28, restated as an explicit Lean theorem. -/
 theorem proof_isIntegral_iff_exists_map_eq_minpoly [IsFractionRing A K] {α : L} :

--- a/progress/2026-04-21T22-28-22Z_6011e749.md
+++ b/progress/2026-04-21T22-28-22Z_6011e749.md
@@ -1,0 +1,24 @@
+## Accomplished
+
+- Claimed issue `#615` for the Stage 3.7 follow-up on `Chapter1/01_28_Proof`.
+- Read the proof blob and the corresponding Lean proposition/proof files, then confirmed the proof file's main theorem preserves lighter assumptions than the proposition file.
+- Removed the unused helper wrappers `minpoly_dvd_of_monic_lifted_root` and `minpoly_coeff_lifts_to_base` from `SutherlandNumberTheoryLecture1/Chapter1/01_28_Proof.lean`, leaving only the proof-blob equivalence theorem that still carries independent value.
+- Ran `lake exe cache get` for the session and verified the repository with `lake build` successfully.
+
+## Current frontier
+
+- Issue `#615` is ready to publish as a PR from this worktree.
+
+## Overall project progress
+
+- Phase 1 and Phase 2 remain complete.
+- Chapter 1 is still in late Stage 3, with Stage 3.7 upstreaming cleanup continuing across proof blobs that were classified as Mathlib-covered.
+- `01_28_Proof` has now been trimmed so it no longer exports redundant wrapper lemmas around existing Mathlib/in-project integrally-closed minimal-polynomial API.
+
+## Next step
+
+- Publish the PR for `#615`, then continue with the next oldest unclaimed Stage 3.7 refactor issue (`#621`, `#624`, `#627`, or `#636`).
+
+## Blockers
+
+- The optional `second-opinion` tool did not return before publication; local verification completed successfully without it.


### PR DESCRIPTION
Closes #615

Session: `6011e749-a168-4ae7-9b35-f3a84df9ada6`

e757359 refactor: trim 01_28 proof wrappers (Fixes #615, progress/2026-04-21T22-28-22Z_6011e749.md)

🤖 Prepared with Claude Code