### PR TITLE
Refactor Chapter1/01_18_Proof to cite Mathlib IsIntegral closure lemmas directly

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_18_Proof.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_18_Proof.lean
@@ -1,4 +1,4 @@
-import SutherlandNumberTheoryLecture1.Chapter1.«01_18_Proposition»
+import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 
 /-!
 # Proof of Proposition 1.18
@@ -6,9 +6,9 @@ import SutherlandNumberTheoryLecture1.Chapter1.«01_18_Proposition»
 The lecture proves closure of integral elements under addition and
 multiplication by reducing to a universal quotient and then constructing the
 annihilating polynomials from the roots of the input monic polynomials. Mathlib
-already provides the same conclusions abstractly, so this proof blob is
-formalized as explicit Lean declarations citing the established closure lemmas
-rather than reconstructing the symmetric-polynomial argument.
+already provides the same conclusions abstractly as `IsIntegral.add` and
+`IsIntegral.mul`, so this proof blob cites those declarations directly rather
+than routing through an extra project-local wrapper layer.
 -/
 
 namespace SutherlandNumberTheoryLecture1
@@ -18,15 +18,15 @@ section Proof_01_18
 
 variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
 
-/-- The proof blob's sum claim is discharged by the previously scaffolded proposition. -/
+/-- The proof blob's sum claim is Mathlib's closure of integral elements under addition. -/
 theorem proof_integral_add {α β : B} (hα : IsIntegral A α) (hβ : IsIntegral A β) :
-    IsIntegral A (α + β) :=
-  integral_add hα hβ
+    IsIntegral A (α + β) := by
+  simpa using IsIntegral.add (R := A) (A := B) hα hβ
 
-/-- The proof blob's product claim is discharged by the previously scaffolded proposition. -/
+/-- The proof blob's product claim is Mathlib's closure of integral elements under multiplication. -/
 theorem proof_integral_mul {α β : B} (hα : IsIntegral A α) (hβ : IsIntegral A β) :
-    IsIntegral A (α * β) :=
-  integral_mul hα hβ
+    IsIntegral A (α * β) := by
+  simpa using IsIntegral.mul (R := A) (A := B) hα hβ
 
 end Proof_01_18
 

--- a/progress/2026-04-21T22-39-02Z_b8e36e15.md
+++ b/progress/2026-04-21T22-39-02Z_b8e36e15.md
@@ -1,0 +1,24 @@
+## Accomplished
+
+- Claimed issue `#621` and confirmed `Chapter1/01_18_Proof` was only routing through the project-local proposition wrappers for integral closure under addition and multiplication.
+- Refactored `SutherlandNumberTheoryLecture1/Chapter1/01_18_Proof.lean` to import the specific Mathlib integral-closure module and cite `IsIntegral.add` / `IsIntegral.mul` directly.
+- Updated the proof-file module documentation and theorem docstrings so they describe the direct-Mathlib citation pattern accurately.
+- Ran `lake exe cache get` for the session and verified the repository with a successful full `lake build`.
+
+## Current frontier
+
+- Issue `#621` is implemented, verified, and ready to publish as a PR from branch `agent/b8e36e15`.
+
+## Overall project progress
+
+- Phase 1 and Phase 2 remain complete.
+- Chapter 1 remains in late Stage 3.7 cleanup after verdict generation completed across all proof-polished items.
+- `progress/status.json` still reports `34` `dependency_trimmed`, `11` `proof_polished`, `7` `structured`, and `7` `non_formalizable` items.
+
+## Next step
+
+- Publish the PR for `#621`, then continue with the next direct-Mathlib cleanup issue in queue order (`#624`, `#627`, or `#636`).
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #621

Session: `b8e36e15-ade4-4df5-97b9-41f91d043f7d`

45374d4 fix: cite Mathlib directly in 01_18 proof

🤖 Prepared with Claude Code