### PR TITLE
Refactor Chapter1/01_21_Proof to use Mathlib integral-closure declarations directly

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_21_Proof.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_21_Proof.lean
@@ -7,8 +7,9 @@ The lecture proves Corollary 1.21 by taking the integral closure `A'` of `A`
 in `B`, then the integral closure `A''` of `A'` in `B`, and observing that the
 second closure collapses back to `A'`. Mathlib packages that idempotence as
 `integralClosure_idem`, whose proof uses the same transitivity-of-integrality
-step as the textbook. The final "hence integrally closed" conclusion is exactly
-`IsIntegrallyClosedIn.of_isIntegralClosure`.
+step as the textbook. The corollary file cites Mathlib's ambient
+integrally-closed theorem directly, so this proof blob only retains the
+intermediate idempotence statement that mirrors the lecture's argument.
 -/
 
 namespace SutherlandNumberTheoryLecture1
@@ -21,14 +22,7 @@ variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
 /-- The nested integral closure `A''` from the lecture is equal to `A'` in bundled form. -/
 theorem integralClosure_idempotent_in_ambient :
     integralClosure (integralClosure A B) B = ⊥ := by
-  exact integralClosure_idem (R := A) (A := B)
-
-/-- Repackaging the textbook conclusion: the integral closure of `A` in `B` is integrally
-closed in `B`. -/
-theorem integralClosure_isIntegrallyClosedIn_from_proof :
-    IsIntegrallyClosedIn (integralClosure A B) B := by
-  exact IsIntegrallyClosedIn.of_isIntegralClosure
-    (R := A) (A := integralClosure A B) (B := B)
+  simpa using integralClosure_idem (R := A) (A := B)
 
 end Proof_01_21
 

--- a/progress/2026-04-21T22-42-54Z_ce8fa02e.md
+++ b/progress/2026-04-21T22-42-54Z_ce8fa02e.md
@@ -1,0 +1,24 @@
+## Accomplished
+
+- Claimed issue `#624` and reviewed the proof blob plus the corresponding Lean proof/corollary files for `Chapter1/01_21_Proof`.
+- Simplified `SutherlandNumberTheoryLecture1/Chapter1/01_21_Proof.lean` so it now cites `integralClosure_idem` directly and retains only the nested-integral-closure statement that mirrors the book's proof.
+- Removed the redundant wrapper theorem restating that the integral closure is integrally closed in the ambient ring, since `01_21_Corollary.lean` already cites `IsIntegrallyClosedIn.of_isIntegralClosure` directly.
+- Ran `lake exe cache get` for this session and verified the repository with `lake build`.
+
+## Current frontier
+
+- Issue `#624` is ready to publish as a PR from this worktree.
+
+## Overall project progress
+
+- Phase 1 and Phase 2 remain complete.
+- Chapter 1 remains in late Stage 3.7 cleanup, with proof blobs being trimmed where they only restate existing Mathlib declarations.
+- `01_21_Proof` now keeps only the intermediate idempotence statement from the textbook argument instead of exporting duplicate ambient integrally-closed wrappers.
+
+## Next step
+
+- Publish the PR for `#624`, then continue with the next oldest unclaimed Stage 3.7 refactor issue.
+
+## Blockers
+
+- The optional `second-opinion` review hook did not return in time; local verification completed successfully without it.


### PR DESCRIPTION
Closes #624

Session: `ce8fa02e-ccca-48d4-8ccc-763e66ba093c`

656fda3 fix: trim redundant 01_21 proof wrapper

🤖 Prepared with Claude Code