### PR TITLE
Refactor Chapter1/01_25_Proof to cite Mathlib valuation-ring integrally-closed API directly

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_25_Proof.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_25_Proof.lean
@@ -1,14 +1,15 @@
-import SutherlandNumberTheoryLecture1.Chapter1.«01_25_Proposition»
+import Mathlib.Algebra.GCDMonoid.IntegrallyClosed
+import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
+import Mathlib.RingTheory.Valuation.ValuationRing
 
 /-!
 # Proof of Proposition 1.25
 
 The lecture proves that a valuation ring is integrally closed by contradiction:
-an element of the fraction field that is integral over the ring cannot lie in
-the "inverse is in the ring" branch of the valuation-ring dichotomy, so it must
-already come from the ring itself. Mathlib already packages the final theorem,
-so this proof blob is formalized as an explicit "integral elements lie in the
-ring" witness theorem together with the resulting integrally-closed conclusion.
+an element of the fraction field that is integral over the ring must already lie
+in the ring. Mathlib already packages both the witness-extraction step as
+`IsIntegrallyClosed.algebraMap_eq_of_integral` and the valuation-ring conclusion
+through typeclass search, so this proof blob cites those declarations directly.
 -/
 
 namespace SutherlandNumberTheoryLecture1
@@ -22,15 +23,12 @@ variable {A K : Type*} [CommRing A] [IsDomain A] [Field K] [Algebra A K] [IsFrac
 integral over a valuation ring already comes from the ring. -/
 theorem proof_integral_element_mem [ValuationRing A] {x : K} (hx : IsIntegral A x) :
     ∃ a : A, algebraMap A K a = x := by
-  rcases valuationRing_integer_or_inv_integer (A := A) (K := K) x with hxA | _
-  · exact hxA
-  · exact (isIntegrallyClosed_iff K).mp
-      (valuationRing_isIntegrallyClosed (A := A)) hx
+  simpa using
+    (IsIntegrallyClosed.algebraMap_eq_of_integral (R := A) (K := K) hx)
 
 /-- The proof blob's final conclusion: every valuation ring is integrally closed. -/
-theorem proof_valuationRing_isIntegrallyClosed [ValuationRing A] : IsIntegrallyClosed A :=
-  (isIntegrallyClosed_iff (FractionRing A)).2 fun {_} hx =>
-    proof_integral_element_mem (A := A) (K := FractionRing A) hx
+theorem proof_valuationRing_isIntegrallyClosed [ValuationRing A] : IsIntegrallyClosed A := by
+  infer_instance
 
 end Proof_01_25
 

--- a/progress/2026-04-21T22-47-13Z_1fd8be80.md
+++ b/progress/2026-04-21T22-47-13Z_1fd8be80.md
@@ -1,0 +1,25 @@
+## Accomplished
+
+- Claimed issue `#636` and refactored `SutherlandNumberTheoryLecture1/Chapter1/01_25_Proof.lean` to cite Mathlib directly instead of routing through the local proposition wrapper.
+- Replaced the contradiction-step proof with `IsIntegrallyClosed.algebraMap_eq_of_integral`.
+- Replaced the final valuation-ring conclusion proof with the existing Mathlib-backed instance, exposed via `infer_instance`.
+- Updated the module documentation and imports so the file points at the direct Mathlib sources (`ValuationRing`, `IntegrallyClosed`, and the GCD-domain integrally-closed instance chain).
+- Ran `lake exe cache get` and verified the repository with a successful `lake build`.
+
+## Current frontier
+
+- Issue `#636` is implemented, verified, and ready to publish from branch `agent/1fd8be80`.
+
+## Overall project progress
+
+- Phase 1 and Phase 2 remain complete.
+- Chapter 1 remains in late Stage 3.7 cleanup after verdict generation completed across proof-polished items.
+- `progress/status.json` is unchanged this turn; `Chapter1/01_25_Proof` remains tracked in the existing Stage 3.7 cleanup buckets.
+
+## Next step
+
+- Publish the PR for `#636`, then continue with any newly unclaimed direct-Mathlib cleanup or proof-maintenance issue.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #636

Session: `1fd8be80-3eb9-44ec-9684-d78281677d4f`

de417aa fix: cite Mathlib valuation-ring integrally-closed API directly

🤖 Prepared with Claude Code