### PR TITLE
Collapse redundant Chapter 1 API variants

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_04_Lemma.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_04_Lemma.lean
@@ -18,52 +18,27 @@ section Lemma_01_04
 
 variable {k : Type*} [Field k]
 
-/-- The easy direction of Lemma 1.4 is Mathlib's natural-number estimate. -/
-theorem natCast_le_one_of_isNonarchimedean (abv : AbsoluteValue k ℝ)
-    (hna : IsNonarchimedean abv) :
-    ∀ n : ℕ, abv n ≤ 1 := by
-  intro n
-  simpa using IsNonarchimedean.apply_natCast_le_one_of_isNonarchimedean (f := abv) hna (n := n)
-
-/-- The book phrases the natural-number bound for positive integers `n ≥ 1`. -/
-theorem natCast_pos_le_one_of_isNonarchimedean (abv : AbsoluteValue k ℝ)
-    (hna : IsNonarchimedean abv) :
-    ∀ n : ℕ, 0 < n → abv n ≤ 1 := by
-  intro n hn
-  exact natCast_le_one_of_isNonarchimedean abv hna n
-
-/-- The converse direction is the book-specific bridge deferred to the proof stage. -/
-theorem isNonarchimedean_of_natCast_le_one (abv : AbsoluteValue k ℝ)
-    (h_nat : ∀ n : ℕ, abv n ≤ 1) :
-    IsNonarchimedean abv := by
-  letI : NormedField k := abv.toNormedField
-  letI : IsUltrametricDist k :=
-    IsUltrametricDist.isUltrametricDist_of_forall_norm_natCast_le_one (R := k) <| by
-      simpa using h_nat
-  change IsNonarchimedean (‖·‖ : k → ℝ)
-  simpa using (IsUltrametricDist.isNonarchimedean_norm (R := k))
-
 /-- Lemma 1.4 in the lecture's original `n ≥ 1` form. -/
 theorem isNonarchimedean_iff_natCast_pos_le_one (abv : AbsoluteValue k ℝ) :
     IsNonarchimedean abv ↔ ∀ n : ℕ, 0 < n → abv n ≤ 1 := by
   constructor
-  · exact natCast_pos_le_one_of_isNonarchimedean abv
+  · intro hna n hn
+    simpa using IsNonarchimedean.apply_natCast_le_one_of_isNonarchimedean
+      (f := abv) hna (n := n)
   · intro h_pos
-    apply isNonarchimedean_of_natCast_le_one
-    intro n
-    cases n with
-    | zero =>
-        simpa only [Nat.cast_zero, map_zero] using (show (0 : ℝ) ≤ 1 by norm_num)
-    | succ m =>
-        exact h_pos (Nat.succ m) (Nat.succ_pos m)
-
-/-- Lemma 1.4: an absolute value is nonarchimedean iff
-all natural-number sums have value at most `1`. -/
-theorem isNonarchimedean_iff_natCast_le_one (abv : AbsoluteValue k ℝ) :
-    IsNonarchimedean abv ↔ ∀ n : ℕ, abv n ≤ 1 := by
-  constructor
-  · exact natCast_le_one_of_isNonarchimedean abv
-  · exact isNonarchimedean_of_natCast_le_one abv
+    let h_nat : ∀ n : ℕ, abv n ≤ 1 := by
+      intro n
+      cases n with
+      | zero =>
+          simpa only [Nat.cast_zero, map_zero] using (show (0 : ℝ) ≤ 1 by norm_num)
+      | succ m =>
+          exact h_pos (Nat.succ m) (Nat.succ_pos m)
+    letI : NormedField k := abv.toNormedField
+    letI : IsUltrametricDist k :=
+      IsUltrametricDist.isUltrametricDist_of_forall_norm_natCast_le_one (R := k) <| by
+        simpa using h_nat
+    change IsNonarchimedean (‖·‖ : k → ℝ)
+    simpa using (IsUltrametricDist.isNonarchimedean_norm (R := k))
 
 end Lemma_01_04
 

--- a/SutherlandNumberTheoryLecture1/Chapter1/01_05_Corollary.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_05_Corollary.lean
@@ -47,8 +47,8 @@ theorem natCast_absoluteValue_pow_char (abv : AbsoluteValue k ℝ) {p : ℕ}
 theorem absoluteValue_isNonarchimedean_of_pos_char (abv : AbsoluteValue k ℝ) {p : ℕ}
     [Fact p.Prime] [CharP k p] :
     IsNonarchimedean abv := by
-  apply isNonarchimedean_of_natCast_le_one
-  intro n
+  refine (isNonarchimedean_iff_natCast_pos_le_one abv).2 ?_
+  intro n hn
   have hpow : abv n ^ p = abv n := natCast_absoluteValue_pow_char abv (p := p) n
   have hp : 1 < p := (Fact.out : p.Prime).one_lt
   obtain hzero | hone :=

--- a/SutherlandNumberTheoryLecture1/Chapter1/01_28_Proposition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_28_Proposition.lean
@@ -41,14 +41,13 @@ theorem minpoly_dvd_of_fractionRing_aeval_eq_zero [Module.IsTorsionFree A L]
   exact minpoly.isIntegrallyClosed_dvd hα hf'
 
 /-- Proposition 1.28: over an integrally closed domain, integrality is equivalent to the
-minimal polynomial over the fraction field having coefficients in the base ring.
+minimal polynomial over the fraction field coming from a base-ring polynomial.
 -/
-theorem isIntegral_iff_minpoly_eq_map [IsFractionRing A K] [FiniteDimensional K L] {α : L} :
-    IsIntegral A α ↔ ∃ f : A[X], f.map (algebraMap A K) = minpoly K α := by
+theorem integral_iff_minpoly_over_base [IsFractionRing A K] [FiniteDimensional K L] {α : L} :
+    IsIntegral A α ↔ ∃ f : A[X], minpoly K α = f.map (algebraMap A K) := by
   constructor
   · intro hα
     refine ⟨minpoly A α, ?_⟩
-    symm
     exact minpoly.isIntegrallyClosed_eq_field_fractions' K hα
   · rintro ⟨f, hf_eq⟩
     have hαK : IsIntegral K α := Algebra.IsIntegral.isIntegral (R := K) α
@@ -56,26 +55,12 @@ theorem isIntegral_iff_minpoly_eq_map [IsFractionRing A K] [FiniteDimensional K 
       apply Polynomial.monic_of_injective (f := algebraMap A K) (IsFractionRing.injective A K)
       simpa [hf_eq] using minpoly.monic hαK
     have hf_rootK : aeval α (f.map (algebraMap A K)) = 0 := by
-      rw [hf_eq]
+      rw [← hf_eq]
       exact minpoly.aeval K α
     have hf_rootA : aeval α f = 0 := by
       simpa [Polynomial.aeval_map_algebraMap K α f] using hf_rootK
     refine ⟨f, hf_monic, ?_⟩
     exact hf_rootA
-
-/-- Compatibility wrapper exposing Proposition 1.28 with an explicit monic lift. -/
-theorem isIntegral_iff_exists_map_eq_minpoly [IsFractionRing A K] [FiniteDimensional K L] {α : L} :
-    IsIntegral A α ↔ ∃ f : A[X], f.Monic ∧ f.map (algebraMap A K) = minpoly K α := by
-  constructor
-  · intro hα
-    rcases (isIntegral_iff_minpoly_eq_map (A := A) (K := K) (L := L) (α := α)).mp hα with ⟨f, hf_eq⟩
-    have hαK : IsIntegral K α := Algebra.IsIntegral.isIntegral (R := K) α
-    have hf_monic : f.Monic := by
-      apply Polynomial.monic_of_injective (f := algebraMap A K) (IsFractionRing.injective A K)
-      simpa [hf_eq] using minpoly.monic hαK
-    exact ⟨f, hf_monic, hf_eq⟩
-  · rintro ⟨f, _, hf_eq⟩
-    exact (isIntegral_iff_minpoly_eq_map (A := A) (K := K) (L := L) (α := α)).mpr ⟨f, hf_eq⟩
 
 end Proposition_01_28
 

--- a/progress/2026-04-23T04-48-47Z.md
+++ b/progress/2026-04-23T04-48-47Z.md
@@ -1,0 +1,19 @@
+## Accomplished
+- Claimed human-oversight issue `#774` via REST fallback because the `coordination` script's GraphQL repo lookup is currently rate-limited.
+- Collapsed the redundant exported Lemma `1.4` variants in [01_04_Lemma.lean](/home/kim/Sutherland-NumberTheory-Lecture1-draft3/worktrees/e57ec73a/SutherlandNumberTheoryLecture1/Chapter1/01_04_Lemma.lean) so the book's `n ≥ 1` formulation `isNonarchimedean_iff_natCast_pos_le_one` is now the only public characterization theorem.
+- Updated [01_05_Corollary.lean](/home/kim/Sutherland-NumberTheory-Lecture1-draft3/worktrees/e57ec73a/SutherlandNumberTheoryLecture1/Chapter1/01_05_Corollary.lean) to use the canonical Lemma `1.4` statement directly.
+- Renamed the canonical Proposition `1.28` API in [01_28_Proposition.lean](/home/kim/Sutherland-NumberTheory-Lecture1-draft3/worktrees/e57ec73a/SutherlandNumberTheoryLecture1/Chapter1/01_28_Proposition.lean) to `integral_iff_minpoly_over_base` and removed the two redundant exported variants.
+- Ran `lake exe cache get` and `lake build`; the full project now builds successfully.
+
+## Current frontier
+- Issue `#774` is complete locally and ready for commit / PR publication.
+
+## Overall project progress
+- The Chapter `1` human-oversight cleanup wave continues to simplify the exported API without changing the underlying formalized mathematics.
+- The repository remains on a green build after this cleanup pass.
+
+## Next step
+- Commit the `#774` API-pruning changes together with this progress file, publish the branch, and create the PR with auto-merge if the GitHub rate limit permits.
+
+## Blockers
+- GitHub GraphQL is rate-limited for this token, so `coordination` and `gh pr create` may require REST fallbacks until the quota resets.


### PR DESCRIPTION
Closes #774

## Summary
- keep only the book-form Lemma 1.4 characterization theorem
- switch Corollary 1.5 to the canonical Lemma 1.4 API
- keep only the canonical Proposition 1.28 theorem name and remove duplicate exported variants